### PR TITLE
ffmpeg: additional video formats and config system

### DIFF
--- a/animatediff/model_utils.py
+++ b/animatediff/model_utils.py
@@ -46,6 +46,13 @@ folder_names_and_paths[Folders.MODELS] = ([MODEL_DIR], folder_paths.supported_pt
 
 filename_list_cache = {}
 
+#Register video_formats folder
+folder_paths.folder_names_and_paths["video_formats"] = (
+    [
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "video_formats"),
+    ],
+    [".json"]
+)
 
 def get_filename_list_(folder_name):
     global folder_names_and_paths

--- a/video_formats/av1-webm.json
+++ b/video_formats/av1-webm.json
@@ -1,0 +1,10 @@
+{
+    "main_pass":
+    [
+        "-n", "-c:v", "libsvtav1",
+        "-pix_fmt", "yuv420p10le",
+        "-crf", "23"
+    ],
+     "extension": "webm",
+     "environment": {"SVT_LOG": "1"}
+}

--- a/video_formats/h264-mp4.json
+++ b/video_formats/h264-mp4.json
@@ -1,0 +1,9 @@
+{
+    "main_pass":
+    [
+        "-n", "-c:v", "libx264",
+        "-pix_fmt", "yuv420p",
+        "-crf", "19"
+    ],
+     "extension": "mp4"
+}

--- a/video_formats/h265-mp4.json
+++ b/video_formats/h265-mp4.json
@@ -1,0 +1,11 @@
+{
+    "main_pass":
+    [
+        "-n", "-c:v", "libx265",
+        "-pix_fmt", "yuv420p10le",
+        "-preset", "medium",
+        "-crf", "22",
+        "-x265-params", "log-level=quiet"
+    ],
+     "extension": "mp4"
+}

--- a/video_formats/webm.json
+++ b/video_formats/webm.json
@@ -1,0 +1,9 @@
+{
+    "main_pass":
+    [
+        "-n",
+        "-pix_fmt", "yuv420p",
+        "-crf", "23"
+    ],
+     "extension": "webm"
+}


### PR DESCRIPTION
This allows for ffmpeg output settings to be set from a series of json config files stored in video_formats. It improves the quality of (vp9) webm outputs, adds support for additional codecs (h264, h265, av1), and allows end users to add additional output formats in a way that doesn't conflict with future updates.

In addition to these changes, the logging of ffmpeg is better handled. Error messages from ffmpeg itself are printed and logging from encoders that was improperly filtered have been individually addressed.

While h265 has been included, most browsers will be unable to display the resulting video.