### PR TITLE
Possible fixes to uniform context window generator

### DIFF
--- a/animatediff/context.py
+++ b/animatediff/context.py
@@ -149,6 +149,8 @@ def get_context_scheduler(name: str) -> Callable:
             return uniform
         case ContextSchedules.UNIFORM_CONSTANT:
             return uniform_constant
+        case ContextSchedules.UNIFORM_V2:
+            return uniform_v2
         case _:
             raise ValueError(f"Unknown context_overlap policy {name}")
 


### PR DESCRIPTION
I've taken the time to read over the new sliding context code, but I noticed a couple of irregularities in the uniform context window generator.

- On the highest context_stride, frames can appear in the context window twice.
    - I think this causes cascading errors in the sliding_conditioning evaluation at a minimum by failing to increment out_count_final multiple times.
- closed_loop causes context_overlap to be ignored. Context windows will loop from the end to the start regardless of its setting.

While I've drafted changes here to fix the irregularities I'm noticing, I don't have numerical proof that the changes increase the quality of the output, and don't even have a compatible gpu to do proper A/B testing with the large frame numbers required. I'd appreciate it if others could assist in testing/provide insight, but I would consider it low priority since there's a good chance I'm just misunderstanding the new code.
