### PR TITLE
Support saving and loading workflows from video metadata

### DIFF
--- a/animatediff/nodes.py
+++ b/animatediff/nodes.py
@@ -487,11 +487,14 @@ class AnimateDiffCombine:
         ) = folder_paths.get_save_image_path(filename_prefix, output_dir)
 
         metadata = PngInfo()
+        video_metadata = {}
         if prompt is not None:
             metadata.add_text("prompt", json.dumps(prompt))
+            video_metadata["prompt"] = prompt
         if extra_pnginfo is not None:
             for x in extra_pnginfo:
                 metadata.add_text(x, json.dumps(extra_pnginfo[x]))
+                video_metadata[x] = extra_pnginfo[x]
 
         # save first frame as png to keep metadata
         file = f"{filename}_{counter:05}_.png"
@@ -533,7 +536,7 @@ class AnimateDiffCombine:
             dimensions = f"{frames[0].width}x{frames[0].height}"
             args = [ffmpeg_path, "-v", "error", "-f", "rawvideo", "-pix_fmt", "rgb24",
                     "-s", dimensions, "-r", str(frame_rate), "-i", "-"] \
-                    + video_format['main_pass'] + [file_path]
+                    + video_format['main_pass'] + ["-metadata", "comment=" + json.dumps(video_metadata), file_path]
 
             env=os.environ.copy()
             if  "environment" in video_format:

--- a/animatediff/nodes.py
+++ b/animatediff/nodes.py
@@ -541,7 +541,9 @@ class AnimateDiffCombine:
                 max_arg_length = 4096*32
             else:
                 max_arg_length = 32767
-            if len(metadata_args[1]) > max_arg_length:
+            #test max limit
+            #metadata_args[1] = metadata_args[1] + "a"*(max_arg_length - len(metadata_args[1])-1)
+            if len(metadata_args[1]) >= max_arg_length:
                 logger.warn(f"Metadata was too long to be embedded in video output: {len(metadata_args[1])}/{max_arg_length}")
                 metadata_args = []
             args = [ffmpeg_path, "-v", "error", "-f", "rawvideo", "-pix_fmt", "rgb24",

--- a/web/js/videoinfo.js
+++ b/web/js/videoinfo.js
@@ -1,0 +1,87 @@
+import { app } from '../../../scripts/app.js'
+
+
+function getVideoMetadata(file) {
+    return new Promise((r) => {
+        const reader = new FileReader();
+        reader.onload = (event) => {
+            const videoData = new Uint8Array(event.target.result);
+            const dataView = new DataView(videoData.buffer);
+
+            let txt = "";
+            // Check for known valid magic strings
+            if (dataView.getUint32(0) == 0x1A45DFA3) {
+                //webm
+                //see http://wiki.webmproject.org/webm-metadata/global-metadata
+                //and maybe https://www.webmproject.org/docs/container/
+                console.log("parsing webm");
+                //contrary to specs, tag seems consistently at start
+                //COMMENT + 0x4487 + packed length?
+                //length 0x8d9 becomes 0x48d8
+                let offset = 4 + 8; //COMMENT is 7 chars + 1 to realign
+                while(offset < videoData.length) {
+                    //Check for text tags
+                    if (dataView.getUint16(offset) == 0x4487) {
+                        //check that name of tag is COMMENT
+                        const name = String.fromCharCode(...videoData.slice(offset-7,offset));
+                        if (name === "COMMENT") {
+                            console.log("found comment");
+                            let length = dataView.getUint16(offset+2) & 0x3FFF;
+                            console.log(length);
+                            const content = String.fromCharCode(...videoData.slice(offset+4, offset+4+length));
+                            console.log(content);
+                            r(JSON.parse(content));
+                            return;
+                        }
+                    }
+                    offset+=2;
+                }
+            } else if (dataView.getUint32(4) == 0x66747970 && dataView.getUint32(8) == 0x69736F6D) {
+                //mp4
+                console.error("not yet implemented")
+            } else {
+                console.error("Unknown magic: " + dataView.getUint32(0))
+                r();
+                return;
+            }
+
+        };
+
+        reader.readAsArrayBuffer(file);
+    });
+}
+function isVideoFile(file) {
+    if (file.name?.endsWith(".webm")) {
+        return true;
+    }
+    if (file.name?.endsWith(".mp4")) {
+        return true;
+    }
+
+    return false;
+}
+
+async function handleFile(file) {
+    console.log("intercepted file call");
+    if (file.type.startsWith("video/") || isVideoFile(file)) {
+        console.log("got video");
+        const videoInfo = await getVideoMetadata(file);
+        if (videoInfo) {
+            if (videoInfo.workflow) {
+                console.log("loading workflow");
+                app.loadGraphData(videoInfo.workflow);
+            }
+            //Potentially check for/parse A1111 metadata here.
+        }
+    } else {
+        console.log("calling original HandleFile");
+        await app.originalHandleFile(file);
+    }
+}
+
+//Storing the original function in app is probably a major no-no
+//But it's the only way I've found to maintain keep the 'this' reference
+app.originalHandleFile = app.handleFile;
+app.handleFile = handleFile;
+//hijack comfy-file-input to allow webm/mp4
+document.getElementById("comfy-file-input").accept += ",video/webm,video/mp4";

--- a/web/js/videoinfo.js
+++ b/web/js/videoinfo.js
@@ -8,7 +8,7 @@ function getVideoMetadata(file) {
             const videoData = new Uint8Array(event.target.result);
             const dataView = new DataView(videoData.buffer);
 
-            let txt = "";
+            let decoder = new TextDecoder();
             // Check for known valid magic strings
             if (dataView.getUint32(0) == 0x1A45DFA3) {
                 //webm
@@ -30,7 +30,7 @@ function getVideoMetadata(file) {
                             let n_octets = Math.clz32(vint)+1;
                             if (n_octets < 4) {//250MB sanity cutoff
                                 let length = (vint >> (8*(4-n_octets))) & ~(1 << (7*n_octets));
-                                const content = String.fromCharCode(...videoData.slice(offset+2+n_octets, offset+2+n_octets+length));
+                                const content = decoder.decode(videoData.slice(offset+2+n_octets, offset+2+n_octets+length));
                                 const json = JSON.parse(content);
                                 r(json);
                                 return;
@@ -50,7 +50,7 @@ function getVideoMetadata(file) {
                             let type = dataView.getUint32(offset+4); //seemingly 1
                             let locale = dataView.getUint32(offset+8); //seemingly 0
                             let size = dataView.getUint32(offset-4) - 4*4;
-                            const content = String.fromCharCode(...videoData.slice(offset+12, offset+12+size));
+                            const content = decoder.decode(videoData.slice(offset+12, offset+12+size));
                             const json = JSON.parse(content);
                             r(json);
                             return;

--- a/web/js/videoinfo.js
+++ b/web/js/videoinfo.js
@@ -52,7 +52,6 @@ function getVideoMetadata(file) {
                             let size = dataView.getUint32(offset-4) - 4*4;
                             const content = String.fromCharCode(...videoData.slice(offset+12, offset+12+size));
                             const json = JSON.parse(content);
-                            console.log(json);
                             r(json);
                             return;
                         }
@@ -72,10 +71,10 @@ function getVideoMetadata(file) {
     });
 }
 function isVideoFile(file) {
-    if (file.name?.endsWith(".webm")) {
+    if (file?.name?.endsWith(".webm")) {
         return true;
     }
-    if (file.name?.endsWith(".mp4")) {
+    if (file?.name?.endsWith(".mp4")) {
         return true;
     }
 
@@ -83,7 +82,7 @@ function isVideoFile(file) {
 }
 
 async function handleFile(file) {
-    if (file.type?.startsWith("video/") || isVideoFile(file)) {
+    if (file?.type?.startsWith("video/") || isVideoFile(file)) {
         const videoInfo = await getVideoMetadata(file);
         if (videoInfo) {
             if (videoInfo.workflow) {
@@ -93,7 +92,6 @@ async function handleFile(file) {
             //Potentially check for/parse A1111 metadata here.
         }
     } else {
-        console.log("calling original HandleFile");
         await app.originalHandleFile(file);
     }
 }


### PR DESCRIPTION
Like with pngs, the workflow used to generate a video can now be restored by dragging and dropping it into the webui, or by clicking the load button.

The method used for saving the metadata has a maximum length of ~32 KB on Windows and ~137 KB on Linux. I don't think hitting this would happen under normal working conditions, but embedding will be skipped with a warning if it ever occurs.

Because of this limit, a lack of support for animated pictures like gif/webp, and safety in case I've missed an edge case, the metadata is still saved in a png of the first frame.

As with loading metadata from a png, the video files are processed in javascript on the client side, and a video that lacks or has invalid metadata fails silently.