### PR TITLE
Renamed "linear (default)" to "linear (HotshotXL/default)" to make it…

### DIFF
--- a/animatediff/model_utils.py
+++ b/animatediff/model_utils.py
@@ -28,7 +28,7 @@ class IsChangedHelper:
 
 class BetaSchedules:
     SQRT_LINEAR = "sqrt_linear (AnimateDiff)"
-    LINEAR = "linear (default)"
+    LINEAR = "linear (HotshotXL/default)"
     SQRT = "sqrt"
     COSINE = "cosine"
     SQUAREDCOS_CAP_V2 = "squaredcos_cap_v2"


### PR DESCRIPTION
… clear which beta_schedule is intended for HotshotXL use