### PR TITLE
feat(FolderPaths): Allow use of custom folders via extra_model_paths

### DIFF
--- a/animatediff/model_utils.py
+++ b/animatediff/model_utils.py
@@ -80,31 +80,21 @@ class Folders:
     ANIMATEDIFF_MODELS = "AnimateDiffEvolved_Models"
     MOTION_LORA = "AnimateDiffMotion_LoRA"
 
+def _register_folder_path(folder_name: str, folder_path: str, extensions: set = None):
+    if folder_name in folder_paths.folder_names_and_paths:
+        folder_paths.folder_names_and_paths[folder_name][0].append(folder_path)
+        if extensions is not None:
+            folder_paths.folder_names_and_paths[folder_name][1].update(extensions)
+    else:
+        folder_paths.folder_names_and_paths[folder_name] = ([folder_path], extensions)
+
 
 # register motion models folder(s)
-folder_paths.folder_names_and_paths[Folders.ANIMATEDIFF_MODELS] = (
-    [
-        str(Path(__file__).parent.parent / "models")
-    ],
-    folder_paths.supported_pt_extensions
-)
-
+_register_folder_path(Folders.ANIMATEDIFF_MODELS, str(Path(__file__).parent.parent / "models"), folder_paths.supported_pt_extensions)
 # register motion LoRA folder(s)
-folder_paths.folder_names_and_paths[Folders.MOTION_LORA] = (
-    [
-        str(Path(__file__).parent.parent / "motion_lora")
-    ],
-    folder_paths.supported_pt_extensions
-)
-
-
-#Register video_formats folder
-folder_paths.folder_names_and_paths["video_formats"] = (
-    [
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "video_formats"),
-    ],
-    [".json"]
-)
+_register_folder_path(Folders.MOTION_LORA, str(Path(__file__).parent.parent / "motion_lora"), folder_paths.supported_pt_extensions)
+# register video_formats folder
+_register_folder_path("video_formats", os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "video_formats"), {".json"})
 
 
 def get_available_motion_models():


### PR DESCRIPTION
**Feature**: Custom Folder Path Support via extra_model_paths

**Description**:
This enhancement allows users to specify custom folder paths via the extra_model_paths configuration file.

**Link**: [extra_model_paths.yaml.example](https://github.com/comfyanonymous/ComfyUI/blob/master/extra_model_paths.yaml.example)

**Usage Example**(extra_model_paths.yaml):

```yaml
comfy_ui:
    AnimateDiffEvolved_Models: /mnt/myAnimateDiffModels/
    AnimateDiffMotion_LoRA: /mnt/myAnimateDiffLoras/
```
**Brief Explanation**:
When comfy starts up, it registers the extra_custom_paths before the nodes are loaded. As a result, we get a mapping with the user-provided paths and an empty set of extensions. As nodes load and register their paths, the user-provided path is subsequently replaced in the process.