### PR TITLE
Added Custom CFG, Sigma Schedule, and relative Fuse Method for Standard Static Context Options

### DIFF
--- a/animatediff/context.py
+++ b/animatediff/context.py
@@ -12,7 +12,8 @@ class ContextFuseMethod:
     PYRAMID = "pyramid"
     RELATIVE = "relative"
 
-    LIST = [PYRAMID, RELATIVE, FLAT]
+    LIST = [PYRAMID, FLAT]
+    LIST_STATIC = [PYRAMID, RELATIVE, FLAT]
 
 
 class ContextType:
@@ -332,6 +333,7 @@ def create_weights_pyramid(length: int, **kwargs) -> list[float]:
 FUSE_MAPPING = {
     ContextFuseMethod.FLAT: create_weights_flat,
     ContextFuseMethod.PYRAMID: create_weights_pyramid,
+    ContextFuseMethod.RELATIVE: create_weights_pyramid,
 }
 
 

--- a/animatediff/context.py
+++ b/animatediff/context.py
@@ -10,8 +10,9 @@ from .utils_motion import get_sorted_list_via_attr
 class ContextFuseMethod:
     FLAT = "flat"
     PYRAMID = "pyramid"
+    RELATIVE = "relative"
 
-    LIST = [PYRAMID, FLAT]
+    LIST = [PYRAMID, RELATIVE, FLAT]
 
 
 class ContextType:

--- a/animatediff/nodes.py
+++ b/animatediff/nodes.py
@@ -6,7 +6,8 @@ from .nodes_gen1 import (AnimateDiffLoaderGen1, LegacyAnimateDiffLoaderWithConte
                          AnimateDiffModelSettingsSimple, AnimateDiffModelSettingsAdvanced, AnimateDiffModelSettingsAdvancedAttnStrengths)
 from .nodes_gen2 import UseEvolvedSamplingNode, ApplyAnimateDiffModelNode, ApplyAnimateDiffModelBasicNode, LoadAnimateDiffModelNode, ADKeyframeNode
 from .nodes_multival import MultivalDynamicNode, MultivalScaledMaskNode
-from .nodes_sample import FreeInitOptionsNode, NoiseLayerAddWeightedNode, SampleSettingsNode, NoiseLayerAddNode, NoiseLayerReplaceNode, IterationOptionsNode
+from .nodes_sample import (FreeInitOptionsNode, NoiseLayerAddWeightedNode, SampleSettingsNode, NoiseLayerAddNode, NoiseLayerReplaceNode, IterationOptionsNode,
+                           CustomCFGNode)
 from .nodes_context import (LegacyLoopedUniformContextOptionsNode, LoopedUniformContextOptionsNode, LoopedUniformViewOptionsNode, StandardUniformContextOptionsNode, StandardStaticContextOptionsNode, BatchedContextOptionsNode,
                             StandardStaticViewOptionsNode, StandardUniformViewOptionsNode, ViewAsContextOptionsNode)
 from .nodes_ad_settings import AnimateDiffSettingsNode, ManualAdjustPENode, SweetspotStretchPENode, FullStretchPENode
@@ -52,6 +53,8 @@ NODE_CLASS_MAPPINGS = {
     "ADE_AdjustPESweetspotStretch": SweetspotStretchPENode,
     "ADE_AdjustPEFullStretch": FullStretchPENode,
     "ADE_AdjustPEManual": ManualAdjustPENode,
+    # Sample Settings
+    "ADE_CustomCFG": CustomCFGNode,
     # Extras Nodes
     "ADE_AnimateDiffUnload": AnimateDiffUnload,
     "ADE_EmptyLatentImageLarge": EmptyLatentImageLarge,
@@ -106,6 +109,8 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ADE_AdjustPESweetspotStretch": "Adjust PE [Sweetspot Stretch] 🎭🅐🅓",
     "ADE_AdjustPEFullStretch": "Adjust PE [Full Stretch] 🎭🅐🅓",
     "ADE_AdjustPEManual": "Adjust PE [Manual] 🎭🅐🅓",
+    # Sample Settings
+    "ADE_CustomCFG": "Custom CFG 🎭🅐🅓",
     # Extras Nodes
     "ADE_AnimateDiffUnload": "AnimateDiff Unload 🎭🅐🅓",
     "ADE_EmptyLatentImageLarge": "Empty Latent Image (Big Batch) 🎭🅐🅓",

--- a/animatediff/nodes.py
+++ b/animatediff/nodes.py
@@ -8,6 +8,7 @@ from .nodes_gen2 import UseEvolvedSamplingNode, ApplyAnimateDiffModelNode, Apply
 from .nodes_multival import MultivalDynamicNode, MultivalScaledMaskNode
 from .nodes_sample import (FreeInitOptionsNode, NoiseLayerAddWeightedNode, SampleSettingsNode, NoiseLayerAddNode, NoiseLayerReplaceNode, IterationOptionsNode,
                            CustomCFGNode, CustomCFGKeyframeNode)
+from .nodes_sigma_schedule import (SigmaScheduleNode, RawSigmaScheduleNode, WeightedAverageSigmaScheduleNode, InterpolatedWeightedAverageSigmaScheduleNode, SplitAndCombineSigmaScheduleNode)
 from .nodes_context import (LegacyLoopedUniformContextOptionsNode, LoopedUniformContextOptionsNode, LoopedUniformViewOptionsNode, StandardUniformContextOptionsNode, StandardStaticContextOptionsNode, BatchedContextOptionsNode,
                             StandardStaticViewOptionsNode, StandardUniformViewOptionsNode, ViewAsContextOptionsNode)
 from .nodes_ad_settings import AnimateDiffSettingsNode, ManualAdjustPENode, SweetspotStretchPENode, FullStretchPENode
@@ -56,6 +57,11 @@ NODE_CLASS_MAPPINGS = {
     # Sample Settings
     "ADE_CustomCFG": CustomCFGNode,
     "ADE_CustomCFGKeyframe": CustomCFGKeyframeNode,
+    "ADE_SigmaSchedule": SigmaScheduleNode,
+    "ADE_RawSigmaSchedule": RawSigmaScheduleNode,
+    "ADE_SigmaScheduleWeightedAverage": WeightedAverageSigmaScheduleNode,
+    "ADE_SigmaScheduleWeightedAverageInterp": InterpolatedWeightedAverageSigmaScheduleNode,
+    "ADE_SigmaScheduleSplitAndCombine": SplitAndCombineSigmaScheduleNode,
     # Extras Nodes
     "ADE_AnimateDiffUnload": AnimateDiffUnload,
     "ADE_EmptyLatentImageLarge": EmptyLatentImageLarge,
@@ -113,6 +119,11 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     # Sample Settings
     "ADE_CustomCFG": "Custom CFG 🎭🅐🅓",
     "ADE_CustomCFGKeyframe": "Custom CFG Keyframe 🎭🅐🅓",
+    "ADE_SigmaSchedule": "Create Sigma Schedule 🎭🅐🅓",
+    "ADE_RawSigmaSchedule": "Create Raw Sigma Schedule 🎭🅐🅓",
+    "ADE_SigmaScheduleWeightedAverage": "Sigma Schedule Weighted Mean 🎭🅐🅓",
+    "ADE_SigmaScheduleWeightedAverageInterp": "Sigma Schedule Interpolated Mean 🎭🅐🅓",
+    "ADE_SigmaScheduleSplitAndCombine": "Sigma Schedule Split Combine 🎭🅐🅓",
     # Extras Nodes
     "ADE_AnimateDiffUnload": "AnimateDiff Unload 🎭🅐🅓",
     "ADE_EmptyLatentImageLarge": "Empty Latent Image (Big Batch) 🎭🅐🅓",

--- a/animatediff/nodes.py
+++ b/animatediff/nodes.py
@@ -134,5 +134,5 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     # Deprecated Nodes
     "AnimateDiffLoaderV1": "AnimateDiff Loader [DEPRECATED] 🎭🅐🅓",
     "ADE_AnimateDiffLoaderV1Advanced": "AnimateDiff Loader (Advanced) [DEPRECATED] 🎭🅐🅓",
-    "ADE_AnimateDiffCombine": "DO NOT USE, USE VideoCombine from ComfyUI-VideoHelperSuite instead! AnimateDiff Combine [DEPRECATED, DO NOT USE] 🎭🅐🅓",
+    "ADE_AnimateDiffCombine": "AnimateDiff Combine [DEPRECATED, Use Video Combine (VHS) Instead!] 🎭🅐🅓",
 }

--- a/animatediff/nodes.py
+++ b/animatediff/nodes.py
@@ -7,7 +7,7 @@ from .nodes_gen1 import (AnimateDiffLoaderGen1, LegacyAnimateDiffLoaderWithConte
 from .nodes_gen2 import UseEvolvedSamplingNode, ApplyAnimateDiffModelNode, ApplyAnimateDiffModelBasicNode, LoadAnimateDiffModelNode, ADKeyframeNode
 from .nodes_multival import MultivalDynamicNode, MultivalScaledMaskNode
 from .nodes_sample import (FreeInitOptionsNode, NoiseLayerAddWeightedNode, SampleSettingsNode, NoiseLayerAddNode, NoiseLayerReplaceNode, IterationOptionsNode,
-                           CustomCFGNode)
+                           CustomCFGNode, CustomCFGKeyframeNode)
 from .nodes_context import (LegacyLoopedUniformContextOptionsNode, LoopedUniformContextOptionsNode, LoopedUniformViewOptionsNode, StandardUniformContextOptionsNode, StandardStaticContextOptionsNode, BatchedContextOptionsNode,
                             StandardStaticViewOptionsNode, StandardUniformViewOptionsNode, ViewAsContextOptionsNode)
 from .nodes_ad_settings import AnimateDiffSettingsNode, ManualAdjustPENode, SweetspotStretchPENode, FullStretchPENode
@@ -55,6 +55,7 @@ NODE_CLASS_MAPPINGS = {
     "ADE_AdjustPEManual": ManualAdjustPENode,
     # Sample Settings
     "ADE_CustomCFG": CustomCFGNode,
+    "ADE_CustomCFGKeyframe": CustomCFGKeyframeNode,
     # Extras Nodes
     "ADE_AnimateDiffUnload": AnimateDiffUnload,
     "ADE_EmptyLatentImageLarge": EmptyLatentImageLarge,
@@ -111,6 +112,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ADE_AdjustPEManual": "Adjust PE [Manual] 🎭🅐🅓",
     # Sample Settings
     "ADE_CustomCFG": "Custom CFG 🎭🅐🅓",
+    "ADE_CustomCFGKeyframe": "Custom CFG Keyframe 🎭🅐🅓",
     # Extras Nodes
     "ADE_AnimateDiffUnload": "AnimateDiff Unload 🎭🅐🅓",
     "ADE_EmptyLatentImageLarge": "Empty Latent Image (Big Batch) 🎭🅐🅓",

--- a/animatediff/nodes_context.py
+++ b/animatediff/nodes_context.py
@@ -145,7 +145,7 @@ class StandardStaticContextOptionsNode:
                 "context_overlap": ("INT", {"default": 4, "min": 0, "max": OVERLAP_MAX}),
             },
             "optional": {
-                "fuse_method": (ContextFuseMethod.LIST,),
+                "fuse_method": (ContextFuseMethod.LIST_STATIC,),
                 "use_on_equal_length": ("BOOLEAN", {"default": False},),
                 "start_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001}),
                 "guarantee_steps": ("INT", {"default": 1, "min": 0, "max": BIGMAX}),

--- a/animatediff/nodes_deprecated.py
+++ b/animatediff/nodes_deprecated.py
@@ -12,7 +12,7 @@ from PIL.PngImagePlugin import PngInfo
 import folder_paths
 from comfy.model_patcher import ModelPatcher
 
-from .context import ContextSchedules, ContextOptions
+from .context import ContextOptionsGroup, ContextOptions, ContextSchedules
 from .logger import logger
 from .utils_model import Folders, BetaSchedules, get_available_motion_models
 from .model_injection import ModelPatcherAndInjector, InjectionParams, MotionModelGroup, load_motion_module_gen1
@@ -109,16 +109,18 @@ class AnimateDiffLoaderAdvanced_Deprecated:
                 model_name=model_name,
                 apply_v2_properly=False,
         )
-        # set context settings
-        params.set_context(
+        context_group = ContextOptionsGroup()
+        context_group.add(
             ContextOptions(
                 context_length=context_length,
                 context_stride=context_stride,
                 context_overlap=context_overlap,
                 context_schedule=context_schedule,
                 closed_loop=closed_loop,
+                )
             )
-        )
+        # set context settings
+        params.set_context(context_options=context_group)
         # inject for use in sampling code
         model = ModelPatcherAndInjector(model)
         model.motion_models = MotionModelGroup(motion_model)

--- a/animatediff/nodes_extras.py
+++ b/animatediff/nodes_extras.py
@@ -6,13 +6,13 @@ from comfy.model_patcher import ModelPatcher
 from comfy.sd import load_checkpoint_guess_config
 
 from .logger import logger
-from .utils_model import IsChangedHelper, BetaSchedules
+from .utils_model import BetaSchedules
 from .model_injection import get_vanilla_model_patcher
 
 
 class AnimateDiffUnload:
     def __init__(self) -> None:
-        self.change = IsChangedHelper()
+        pass
 
     @classmethod
     def INPUT_TYPES(s):

--- a/animatediff/nodes_gen2.py
+++ b/animatediff/nodes_gen2.py
@@ -59,13 +59,20 @@ class UseEvolvedSamplingNode:
         model.sample_settings = sample_settings if sample_settings is not None else SampleSettings()
         model.motion_injection_params = params
 
-        # save model_sampling from BetaSchedule as object patch
-        # if autoselect, get suggested beta_schedule from motion model
-        if beta_schedule == BetaSchedules.AUTOSELECT and not model.motion_models.is_empty():
-            beta_schedule = model.motion_models[0].model.get_best_beta_schedule(log=True)
-        new_model_sampling = BetaSchedules.to_model_sampling(beta_schedule, model)
-        if new_model_sampling is not None:
-            model.add_object_patch("model_sampling", new_model_sampling)
+        if model.sample_settings.custom_cfg is not None:
+            logger.info("[Sample Settings] custom_cfg is set; will override any KSampler cfg values or patches.")
+
+        if model.sample_settings.sigma_schedule is not None:
+            logger.info("[Sample Settings] sigma_schedule is set; will override beta_schedule.")
+            model.add_object_patch("model_sampling", model.sample_settings.sigma_schedule.clone().model_sampling)
+        else:
+            # save model_sampling from BetaSchedule as object patch
+            # if autoselect, get suggested beta_schedule from motion model
+            if beta_schedule == BetaSchedules.AUTOSELECT and not model.motion_models.is_empty():
+                beta_schedule = model.motion_models[0].model.get_best_beta_schedule(log=True)
+            new_model_sampling = BetaSchedules.to_model_sampling(beta_schedule, model)
+            if new_model_sampling is not None:
+                model.add_object_patch("model_sampling", new_model_sampling)
         
         del m_models
         return (model,)

--- a/animatediff/nodes_sample.py
+++ b/animatediff/nodes_sample.py
@@ -5,7 +5,7 @@ from .freeinit import FreeInitFilter
 from .sample_settings import (FreeInitOptions, IterationOptions,
                               NoiseLayerAdd, NoiseLayerAddWeighted, NoiseLayerGroup, NoiseLayerReplace, NoiseLayerType,
                               SeedNoiseGeneration, SampleSettings, CustomCFGKeyframeGroup, CustomCFGKeyframe)
-from .utils_model import BIGMIN, BIGMAX
+from .utils_model import BIGMIN, BIGMAX, SigmaSchedule
 
 
 class SampleSettingsNode:
@@ -24,6 +24,7 @@ class SampleSettingsNode:
                 "seed_override": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "forceInput": True}),
                 "adapt_denoise_steps": ("BOOLEAN", {"default": False},),
                 "custom_cfg": ("CUSTOM_CFG",),
+                "sigma_schedule": ("SIGMA_SCHEDULE",),
             }
         }
     
@@ -33,9 +34,11 @@ class SampleSettingsNode:
     FUNCTION = "create_settings"
 
     def create_settings(self, batch_offset: int, noise_type: str, seed_gen: str, seed_offset: int, noise_layers: NoiseLayerGroup=None,
-                        iteration_opts: IterationOptions=None, seed_override: int=None, adapt_denoise_steps=False, custom_cfg=None):
+                        iteration_opts: IterationOptions=None, seed_override: int=None, adapt_denoise_steps=False,
+                        custom_cfg: CustomCFGKeyframeGroup=None, sigma_schedule: SigmaSchedule=None):
         sampling_settings = SampleSettings(batch_offset=batch_offset, noise_type=noise_type, seed_gen=seed_gen, seed_offset=seed_offset, noise_layers=noise_layers,
-                                           iteration_opts=iteration_opts, seed_override=seed_override, adapt_denoise_steps=adapt_denoise_steps, custom_cfg=custom_cfg)
+                                           iteration_opts=iteration_opts, seed_override=seed_override, adapt_denoise_steps=adapt_denoise_steps,
+                                           custom_cfg=custom_cfg, sigma_schedule=sigma_schedule)
         return (sampling_settings,)
 
 

--- a/animatediff/nodes_sample.py
+++ b/animatediff/nodes_sample.py
@@ -1,7 +1,10 @@
+from git import Union
 from torch import Tensor
 
 from .freeinit import FreeInitFilter
-from .sample_settings import FreeInitOptions, IterationOptions, NoiseLayerAdd, NoiseLayerAddWeighted, NoiseLayerGroup, NoiseLayerReplace, NoiseLayerType, SeedNoiseGeneration, SampleSettings
+from .sample_settings import (FreeInitOptions, IterationOptions,
+                              NoiseLayerAdd, NoiseLayerAddWeighted, NoiseLayerGroup, NoiseLayerReplace, NoiseLayerType,
+                              SeedNoiseGeneration, SampleSettings, CustomCFG)
 from .utils_model import BIGMIN, BIGMAX
 
 
@@ -20,6 +23,7 @@ class SampleSettingsNode:
                 "iteration_opts": ("ITERATION_OPTS",),
                 "seed_override": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "forceInput": True}),
                 "adapt_denoise_steps": ("BOOLEAN", {"default": False},),
+                "custom_cfg": ("CUSTOM_CFG",),
             }
         }
     
@@ -29,9 +33,9 @@ class SampleSettingsNode:
     FUNCTION = "create_settings"
 
     def create_settings(self, batch_offset: int, noise_type: str, seed_gen: str, seed_offset: int, noise_layers: NoiseLayerGroup=None,
-                        iteration_opts: IterationOptions=None, seed_override: int=None, adapt_denoise_steps=False):
+                        iteration_opts: IterationOptions=None, seed_override: int=None, adapt_denoise_steps=False, custom_cfg=None):
         sampling_settings = SampleSettings(batch_offset=batch_offset, noise_type=noise_type, seed_gen=seed_gen, seed_offset=seed_offset, noise_layers=noise_layers,
-                                           iteration_opts=iteration_opts, seed_override=seed_override, adapt_denoise_steps=adapt_denoise_steps)
+                                           iteration_opts=iteration_opts, seed_override=seed_override, adapt_denoise_steps=adapt_denoise_steps, custom_cfg=custom_cfg)
         return (sampling_settings,)
 
 
@@ -198,3 +202,21 @@ class FreeInitOptionsNode:
                                     filter=filter, d_s=d_s, d_t=d_t, n=n_butterworth, init_type=init_type,
                                     iter_batch_offset=iter_batch_offset, iter_seed_offset=iter_seed_offset)
         return (iter_opts,)
+
+
+class CustomCFGNode:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "cfg_multival": ("MULTIVAL",)
+            }
+        }
+    
+    RETURN_TYPES = ("CUSTOM_CFG",)
+    CATEGORY = "Animate Diff 🎭🅐🅓/sample settings"
+    FUNCTION = "create_custom_cfg"
+
+    def create_custom_cfg(self, cfg_multival: Union[float, Tensor]):
+        # TODO: add support for cfg keyframes
+        return (CustomCFG(cfg_multival=cfg_multival),)

--- a/animatediff/nodes_sigma_schedule.py
+++ b/animatediff/nodes_sigma_schedule.py
@@ -1,0 +1,141 @@
+import torch
+
+from .utils_model import BetaSchedules, SigmaSchedule, ModelSamplingType, ModelSamplingConfig, InterpolationMethod
+
+
+def validate_sigma_schedule_compatibility(schedule_A: SigmaSchedule, schedule_B: SigmaSchedule,
+                                          name_a: str="sigma_schedule_A", name_b: str="sigma_schedule_B"):
+    if schedule_A.total_sigmas() != schedule_B.total_sigmas():
+            raise Exception(f"Weighted Average cannot be taken of Sigma Schedules that do not have the same amount of sigmas; " +
+                            f"{name_a} has {schedule_A.total_sigmas()} sigmas (lcm={schedule_A.is_lcm()}), " +
+                            f"{name_b} has {schedule_B.total_sigmas()} sigmas (lcm={schedule_B.is_lcm()}).")
+
+
+class SigmaScheduleNode:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "beta_schedule": (BetaSchedules.ALIAS_ACTIVE_LIST,),
+            }
+        }
+    
+    RETURN_TYPES = ("SIGMA_SCHEDULE",)
+    CATEGORY = "Animate Diff 🎭🅐🅓/sample settings/sigma schedule"
+    FUNCTION = "get_sigma_schedule"
+
+    def get_sigma_schedule(self, beta_schedule: str):
+        model_type = ModelSamplingType.from_alias(ModelSamplingType.EPS)
+        new_model_sampling = BetaSchedules._to_model_sampling(alias=beta_schedule,
+                                                              model_type=model_type)
+        return (SigmaSchedule(model_sampling=new_model_sampling, model_type=model_type),)
+
+
+class RawSigmaScheduleNode:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "raw_beta_schedule": (BetaSchedules.RAW_BETA_SCHEDULE_LIST,),
+                "linear_start": ("FLOAT", {"default": 0.00085, "min": 0.0, "max": 1.0, "step": 0.000001}),
+                "linear_end": ("FLOAT", {"default": 0.012, "min": 0.0, "max": 1.0, "step": 0.000001}),
+                #"cosine_s": ("FLOAT", {"default": 8e-3, "min": 0.0, "max": 1.0, "step": 0.000001}),
+                "sampling": (ModelSamplingType._FULL_LIST,),
+                "lcm_original_timesteps": ("INT", {"default": 50, "min": 1, "max": 1000}),
+                "lcm_zsnr": ("BOOLEAN", {"default": False}),
+            }
+        }
+    
+    RETURN_TYPES = ("SIGMA_SCHEDULE",)
+    CATEGORY = "Animate Diff 🎭🅐🅓/sample settings/sigma schedule"
+    FUNCTION = "get_sigma_schedule"
+
+    def get_sigma_schedule(self, raw_beta_schedule: str, linear_start: float, linear_end: float,# cosine_s: float,
+                           sampling: str, lcm_original_timesteps: int, lcm_zsnr: bool):
+        new_config = ModelSamplingConfig(beta_schedule=raw_beta_schedule, linear_start=linear_start, linear_end=linear_end)
+        if sampling != ModelSamplingType.LCM:
+            lcm_original_timesteps=None
+            lcm_zsnr=False
+        model_type = ModelSamplingType.from_alias(sampling)    
+        new_model_sampling = BetaSchedules._to_model_sampling(alias=BetaSchedules.AUTOSELECT, model_type=model_type, config_override=new_config, original_timesteps=lcm_original_timesteps)
+        if lcm_zsnr:
+            SigmaSchedule.apply_zsnr(new_model_sampling=new_model_sampling)
+        return (SigmaSchedule(model_sampling=new_model_sampling, model_type=model_type),)
+
+
+class WeightedAverageSigmaScheduleNode:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "schedule_A": ("SIGMA_SCHEDULE",),
+                "schedule_B": ("SIGMA_SCHEDULE",),
+                "weight_A": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.001}),
+            }
+        }
+    
+    RETURN_TYPES = ("SIGMA_SCHEDULE",)
+    CATEGORY = "Animate Diff 🎭🅐🅓/sample settings/sigma schedule"
+    FUNCTION = "get_sigma_schedule"
+
+    def get_sigma_schedule(self, schedule_A: SigmaSchedule, schedule_B: SigmaSchedule, weight_A: float):
+        validate_sigma_schedule_compatibility(schedule_A, schedule_B)
+        new_sigmas = schedule_A.model_sampling.sigmas * weight_A + schedule_B.model_sampling.sigmas * (1-weight_A)
+        combo_schedule = schedule_A.clone()
+        combo_schedule.model_sampling.set_sigmas(new_sigmas)
+        return (combo_schedule,)
+
+
+class InterpolatedWeightedAverageSigmaScheduleNode:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "schedule_A": ("SIGMA_SCHEDULE",),
+                "schedule_B": ("SIGMA_SCHEDULE",),
+                "weight_A_Start": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.001}),
+                "weight_A_End": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.001}),
+                "interpolation": (InterpolationMethod._LIST,),
+            }
+        }
+    
+    RETURN_TYPES = ("SIGMA_SCHEDULE",)
+    CATEGORY = "Animate Diff 🎭🅐🅓/sample settings/sigma schedule"
+    FUNCTION = "get_sigma_schedule"
+
+    def get_sigma_schedule(self, schedule_A: SigmaSchedule, schedule_B: SigmaSchedule,
+                           weight_A_Start: float, weight_A_End: float, interpolation: str):
+        validate_sigma_schedule_compatibility(schedule_A, schedule_B)
+        # get reverse weights, since sigmas are currently reversed
+        weights = InterpolationMethod.get_weights(num_from=weight_A_Start, num_to=weight_A_End,
+                                                  length=schedule_A.total_sigmas(), method=interpolation, reverse=True)
+        weights = weights.to(schedule_A.model_sampling.sigmas.dtype).to(schedule_A.model_sampling.sigmas.device)
+        new_sigmas = schedule_A.model_sampling.sigmas * weights + schedule_B.model_sampling.sigmas * (1.0-weights)
+        combo_schedule = schedule_A.clone()
+        combo_schedule.model_sampling.set_sigmas(new_sigmas)
+        return (combo_schedule,)
+
+
+class SplitAndCombineSigmaScheduleNode:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "schedule_Start": ("SIGMA_SCHEDULE",),
+                "schedule_End": ("SIGMA_SCHEDULE",),
+                "idx_split_percent": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.001})
+            }
+        }
+    
+    RETURN_TYPES = ("SIGMA_SCHEDULE",)
+    CATEGORY = "Animate Diff 🎭🅐🅓/sample settings/sigma schedule"
+    FUNCTION = "get_sigma_schedule"
+
+    def get_sigma_schedule(self, schedule_Start: SigmaSchedule, schedule_End: SigmaSchedule, idx_split_percent: float):
+        validate_sigma_schedule_compatibility(schedule_Start, schedule_End)
+        # first, calculate index to act as split; get diff from 1.0 since sigmas are flipped at this stage
+        idx = int((1.0-idx_split_percent) * schedule_Start.total_sigmas())
+        new_sigmas = torch.cat([schedule_End.model_sampling.sigmas[:idx], schedule_Start.model_sampling.sigmas[idx:]], dim=0)
+        new_schedule = schedule_Start.clone()
+        new_schedule.model_sampling.set_sigmas(new_sigmas)
+        return (new_schedule,)

--- a/animatediff/sample_settings.py
+++ b/animatediff/sample_settings.py
@@ -10,6 +10,7 @@ from comfy.model_base import BaseModel
 
 from . import freeinit
 from .context import ContextOptions, ContextOptionsGroup
+from .utils_model import SigmaSchedule
 from .utils_motion import extend_to_batch_size, get_sorted_list_via_attr, prepare_mask_batch
 from .logger import logger
 
@@ -51,7 +52,8 @@ class NoiseNormalize:
 
 class SampleSettings:
     def __init__(self, batch_offset: int=0, noise_type: str=None, seed_gen: str=None, seed_offset: int=0, noise_layers: 'NoiseLayerGroup'=None,
-                 iteration_opts=None, seed_override:int=None, negative_cond_flipflop=False, adapt_denoise_steps: bool=False, custom_cfg: 'CustomCFGKeyframeGroup'=None):
+                 iteration_opts=None, seed_override:int=None, negative_cond_flipflop=False, adapt_denoise_steps: bool=False,
+                 custom_cfg: 'CustomCFGKeyframeGroup'=None, sigma_schedule: SigmaSchedule=None):
         self.batch_offset = batch_offset
         self.noise_type = noise_type if noise_type is not None else NoiseLayerType.DEFAULT
         self.seed_gen = seed_gen if seed_gen is not None else SeedNoiseGeneration.COMFY
@@ -62,6 +64,7 @@ class SampleSettings:
         self.negative_cond_flipflop = negative_cond_flipflop
         self.adapt_denoise_steps = adapt_denoise_steps
         self.custom_cfg = custom_cfg.clone() if custom_cfg else custom_cfg
+        self.sigma_schedule = sigma_schedule
     
     def prepare_noise(self, seed: int, latents: Tensor, noise: Tensor, extra_seed_offset=0, extra_args:dict={}, force_create_noise=True):
         if self.seed_override is not None:
@@ -97,7 +100,7 @@ class SampleSettings:
     def clone(self):
         return SampleSettings(batch_offset=self.batch_offset, noise_type=self.noise_type, seed_gen=self.seed_gen, seed_offset=self.seed_offset,
                            noise_layers=self.noise_layers.clone(), iteration_opts=self.iteration_opts, seed_override=self.seed_override,
-                           negative_cond_flipflop=self.negative_cond_flipflop, adapt_denoise_steps=self.adapt_denoise_steps, custom_cfg=self.custom_cfg)
+                           negative_cond_flipflop=self.negative_cond_flipflop, adapt_denoise_steps=self.adapt_denoise_steps, custom_cfg=self.custom_cfg, sigma_schedule=self.sigma_schedule)
 
 
 class NoiseLayer:
@@ -550,5 +553,3 @@ class CustomCFGKeyframeGroup:
         if self._current_keyframe != None:
             return self._current_keyframe.cfg_multival
         return None
-        
-        

--- a/animatediff/sample_settings.py
+++ b/animatediff/sample_settings.py
@@ -6,10 +6,11 @@ from torch import Tensor
 import comfy.sample
 import comfy.samplers
 from comfy.model_patcher import ModelPatcher
+from comfy.model_base import BaseModel
 
 from . import freeinit
 from .context import ContextOptions, ContextOptionsGroup
-from .utils_motion import extend_to_batch_size, prepare_mask_batch
+from .utils_motion import extend_to_batch_size, get_sorted_list_via_attr, prepare_mask_batch
 from .logger import logger
 
 
@@ -50,7 +51,7 @@ class NoiseNormalize:
 
 class SampleSettings:
     def __init__(self, batch_offset: int=0, noise_type: str=None, seed_gen: str=None, seed_offset: int=0, noise_layers: 'NoiseLayerGroup'=None,
-                 iteration_opts=None, seed_override:int=None, negative_cond_flipflop=False, adapt_denoise_steps: bool=False, custom_cfg: 'CustomCFG'=None):
+                 iteration_opts=None, seed_override:int=None, negative_cond_flipflop=False, adapt_denoise_steps: bool=False, custom_cfg: 'CustomCFGKeyframeGroup'=None):
         self.batch_offset = batch_offset
         self.noise_type = noise_type if noise_type is not None else NoiseLayerType.DEFAULT
         self.seed_gen = seed_gen if seed_gen is not None else SeedNoiseGeneration.COMFY
@@ -60,7 +61,7 @@ class SampleSettings:
         self.seed_override = seed_override
         self.negative_cond_flipflop = negative_cond_flipflop
         self.adapt_denoise_steps = adapt_denoise_steps
-        self.custom_cfg = custom_cfg
+        self.custom_cfg = custom_cfg.clone() if custom_cfg else custom_cfg
     
     def prepare_noise(self, seed: int, latents: Tensor, noise: Tensor, extra_seed_offset=0, extra_args:dict={}, force_create_noise=True):
         if self.seed_override is not None:
@@ -85,6 +86,14 @@ class SampleSettings:
         # noise prepared now
         return noise
     
+    def pre_run(self, model: ModelPatcher):
+        if self.custom_cfg is not None:
+            self.custom_cfg.reset()
+    
+    def cleanup(self):
+        if self.custom_cfg is not None:
+            self.custom_cfg.reset()
+
     def clone(self):
         return SampleSettings(batch_offset=self.batch_offset, noise_type=self.noise_type, seed_gen=self.seed_gen, seed_offset=self.seed_offset,
                            noise_layers=self.noise_layers.clone(), iteration_opts=self.iteration_opts, seed_override=self.seed_override,
@@ -446,6 +455,9 @@ class CustomCFG:
         self.masks = None
         # TODO: add support for cfg keyframes
     
+    def initialize_timesteps(self, model: BaseModel):
+        pass
+
     def patch_model(self, model: ModelPatcher) -> ModelPatcher:
         def evolved_custom_cfg(args):
             cond: Tensor = args["cond"]
@@ -460,5 +472,108 @@ class CustomCFG:
         model = model.clone()
         model.set_model_sampler_cfg_function(evolved_custom_cfg)
         return model
+
+
+class CustomCFGKeyframe:
+    def __init__(self, cfg_multival: Union[float, Tensor], start_percent=0.0, guarantee_steps=1):
+        self.cfg_multival = cfg_multival
+        # scheduling
+        self.start_percent = float(start_percent)
+        self.start_t = 999999999.9
+        self.guarantee_steps = guarantee_steps
+    
+    def clone(self):
+        c = CustomCFGKeyframe(cfg_multival=self.cfg_multival,
+                              start_percent=self.start_percent, guarantee_steps=self.guarantee_steps)
+        c.start_t = self.start_t
+        return c
+
+
+class CustomCFGKeyframeGroup:
+    def __init__(self):
+        self.keyframes: list[CustomCFGKeyframe] = []
+        self._current_keyframe: CustomCFGKeyframe = None
+        self._current_used_steps: int = 0
+        self._current_index: int = 0
+    
+    def reset(self):
+        self._current_keyframe = None
+        self._current_used_steps = 0
+        self._current_index = 0
+        self._set_first_as_current()
+
+    def add(self, keyframe: CustomCFGKeyframe):
+        # add to end of list, then sort
+        self.keyframes.append(keyframe)
+        self.keyframes = get_sorted_list_via_attr(self.keyframes, "start_percent")
+        self._set_first_as_current()
+
+    def _set_first_as_current(self):
+        if len(self.keyframes) > 0:
+            self._current_keyframe = self.keyframes[0]
+        else:
+            self._current_keyframe = None
+
+    def has_index(self, index: int) -> int:
+        return index >=0 and index < len(self.keyframes)
+
+    def is_empty(self) -> bool:
+        return len(self.keyframes) == 0
+    
+    def clone(self):
+        cloned = CustomCFGKeyframeGroup()
+        for keyframe in self.keyframes:
+            cloned.keyframes.append(keyframe)
+        cloned._set_first_as_current()
+        return cloned
+    
+    def initialize_timesteps(self, model: BaseModel):
+        for keyframe in self.keyframes:
+            keyframe.start_t = model.model_sampling.percent_to_sigma(keyframe.start_percent)
+    
+    def prepare_current_keyframe(self, t: Tensor):
+        curr_t: float = t[0]
+        prev_index = self._current_index
+        # if met guaranteed steps, look for next keyframe in case need to switch
+        if self._current_used_steps >= self._current_keyframe.guarantee_steps:
+            # if has next index, loop through and see if need t oswitch
+            if self.has_index(self._current_index+1):
+                for i in range(self._current_index+1, len(self.keyframes)):
+                    eval_c = self.keyframes[i]
+                    # check if start_t is greater or equal to curr_t
+                    # NOTE: t is in terms of sigmas, not percent, so bigger number = earlier step in sampling
+                    if eval_c.start_t >= curr_t:
+                        self._current_index = i
+                        self._current_keyframe = eval_c
+                        self._current_used_steps = 0
+                        # if guarantee_steps greater than zero, stop searching for other keyframes
+                        if self._current_keyframe.guarantee_steps > 0:
+                            break
+                    # if eval_c is outside the percent range, stop looking further
+                    else: break
+        # update steps current context is used
+        self._current_used_steps += 1
+
+    def patch_model(self, model: ModelPatcher) -> ModelPatcher:
+        def evolved_custom_cfg(args):
+            cond: Tensor = args["cond"]
+            uncond: Tensor = args["uncond"]
+            # cond scale is based purely off of CustomCFG - cond_scale input in sampler is ignored!
+            cond_scale = self.cfg_multival
+            if isinstance(cond_scale, Tensor):
+                cond_scale = prepare_mask_batch(cond_scale.to(cond.dtype).to(cond.device), cond.shape)
+                cond_scale = extend_to_batch_size(cond_scale, cond.shape[0])
+            return uncond + (cond - uncond) * cond_scale
+
+        model = model.clone()
+        model.set_model_sampler_cfg_function(evolved_custom_cfg)
+        return model
+
+    # properties shadow those of CustomCFGKeyframe
+    @property
+    def cfg_multival(self):
+        if self._current_keyframe != None:
+            return self._current_keyframe.cfg_multival
+        return None
         
         

--- a/animatediff/sampling.py
+++ b/animatediff/sampling.py
@@ -147,8 +147,9 @@ def get_additional_models_factory(orig_get_additional_models: Callable, motion_m
 
 def apply_params_to_motion_models(motion_models: MotionModelGroup, params: InjectionParams):
     params = params.clone()
-    if params.context_options.context_schedule == ContextSchedules.VIEW_AS_CONTEXT:
-        params.context_options._current_context.context_length = params.full_length
+    for context in params.context_options.contexts:
+        if context.context_schedule == ContextSchedules.VIEW_AS_CONTEXT:
+            context.context_length = params.full_length
     # TODO: check (and message) should be different based on use_on_equal_length setting
     if params.context_options.context_length:
         pass

--- a/animatediff/sampling.py
+++ b/animatediff/sampling.py
@@ -492,7 +492,7 @@ def sliding_calc_cond_uncond_batch(model, cond, uncond, x_in: Tensor, timestep, 
                     bias_total = bias_final[(full_length*n)+idx]
                     prev_weight = (bias_total / (bias_total + bias))
                     new_weight = (bias / (bias_total + bias))
-                    cond_final[(full_length*n)+idx] = cond_final[(full_length*n)+idx] * prev_weight  + sub_cond_out[(full_length*n)+pos] * new_weight
+                    cond_final[(full_length*n)+idx] = cond_final[(full_length*n)+idx] * prev_weight + sub_cond_out[(full_length*n)+pos] * new_weight
                     uncond_final[(full_length*n)+idx] = uncond_final[(full_length*n)+idx] * prev_weight + sub_uncond_out[(full_length*n)+pos] * new_weight
                     bias_final[(full_length*n)+idx] = bias_total + bias
         else:

--- a/animatediff/sampling.py
+++ b/animatediff/sampling.py
@@ -367,7 +367,8 @@ def evolved_sampling_function(model, x, timestep, uncond, cond, cond_scale, mode
     if ADGS.sample_settings.custom_cfg is not None:
         ADGS.sample_settings.custom_cfg.prepare_current_keyframe(t=timestep)
 
-    if math.isclose(cond_scale, 1.0) and model_options.get("disable_cfg1_optimization", False) == False:
+    # never use cfg1 optimization if using custom_cfg (since can have timesteps and such)
+    if ADGS.sample_settings.custom_cfg is None and math.isclose(cond_scale, 1.0) and model_options.get("disable_cfg1_optimization", False) == False:
         uncond_ = None
     else:
         uncond_ = uncond

--- a/animatediff/utils_model.py
+++ b/animatediff/utils_model.py
@@ -14,18 +14,9 @@ from comfy.model_patcher import ModelPatcher
 import comfy.model_sampling
 import comfy_extras.nodes_model_advanced
 
-BIGMIN = -(2**63-1)
-BIGMAX = (2**63-1)
 
-class IsChangedHelper:
-    def __init__(self):
-        self.val = 0
-    
-    def no_change(self):
-        return self.val
-    
-    def change(self):
-        self.val = (self.val + 1) % 100
+BIGMIN = -(2**53-1)
+BIGMAX = (2**53-1)
 
 
 class ModelSamplingConfig:

--- a/animatediff/utils_model.py
+++ b/animatediff/utils_model.py
@@ -3,11 +3,13 @@ from pathlib import Path
 from typing import Callable, Union
 from collections.abc import Iterable
 from time import time
+import copy
 
+import torch
 import numpy as np
 
 import folder_paths
-from comfy.model_base import SD21UNCLIP, SDXL, BaseModel, SDXLRefiner, SVD_img2vid, model_sampling
+from comfy.model_base import SD21UNCLIP, SDXL, BaseModel, SDXLRefiner, SVD_img2vid, model_sampling, ModelType
 from comfy.model_management import xformers_enabled
 from comfy.model_patcher import ModelPatcher
 
@@ -34,6 +36,19 @@ class ModelSamplingType:
     V_PREDICTION = "v_prediction"
     LCM = "lcm"
 
+    _NON_LCM_LIST = [EPS, V_PREDICTION]
+    _FULL_LIST = [EPS, V_PREDICTION, LCM]
+
+    MAP = {
+        EPS: ModelType.EPS,
+        V_PREDICTION: ModelType.V_PREDICTION,
+        LCM: comfy_extras.nodes_model_advanced.LCM,
+    }
+
+    @classmethod
+    def from_alias(cls, alias: str):
+        return cls.MAP[alias]
+
 
 def factory_model_sampling_discrete_distilled(original_timesteps=50):
     class ModelSamplingDiscreteDistilledEvolved(comfy_extras.nodes_model_advanced.ModelSamplingDiscreteDistilled):
@@ -44,11 +59,13 @@ def factory_model_sampling_discrete_distilled(original_timesteps=50):
 
 
 # based on code in comfy_extras/nodes_model_advanced.py
-def evolved_model_sampling(model_config: ModelSamplingConfig, model_type: int, alias: str):
+def evolved_model_sampling(model_config: ModelSamplingConfig, model_type: ModelType, alias: str, original_timesteps: int=None):
     # if LCM, need to handle manually
-    if BetaSchedules.is_lcm(alias):
+    if BetaSchedules.is_lcm(alias) or original_timesteps is not None:
         sampling_type = comfy_extras.nodes_model_advanced.LCM
-        if alias == BetaSchedules.LCM_100:
+        if original_timesteps is not None:
+            sampling_base = factory_model_sampling_discrete_distilled(original_timesteps=original_timesteps)
+        elif alias == BetaSchedules.LCM_100:
             sampling_base = factory_model_sampling_discrete_distilled(original_timesteps=100)
         elif alias == BetaSchedules.LCM_25:
             sampling_base = factory_model_sampling_discrete_distilled(original_timesteps=25)
@@ -77,11 +94,19 @@ class BetaSchedules:
     SQRT = "sqrt"
     COSINE = "cosine"
     SQUAREDCOS_CAP_V2 = "squaredcos_cap_v2"
+    RAW_LINEAR = "linear"
+    RAW_SQRT_LINEAR = "sqrt_linear"
 
-    LCM_LIST = [LCM, LCM_100, LCM_25, LCM_SQRT_LINEAR]
+    RAW_BETA_SCHEDULE_LIST = [RAW_LINEAR, RAW_SQRT_LINEAR, SQRT, COSINE, SQUAREDCOS_CAP_V2]
 
-    ALIAS_LIST = [AUTOSELECT, USE_EXISTING, SQRT_LINEAR, LINEAR_ADXL, LINEAR, AVG_LINEAR_SQRT_LINEAR, LCM_AVG_LINEAR_SQRT_LINEAR, LCM, LCM_100, LCM_SQRT_LINEAR, # LCM_25 is purposely omitted
+    ALIAS_LCM_LIST = [LCM, LCM_100, LCM_25, LCM_SQRT_LINEAR]
+
+    ALIAS_ACTIVE_LIST = [SQRT_LINEAR, LINEAR_ADXL, LINEAR, AVG_LINEAR_SQRT_LINEAR, LCM_AVG_LINEAR_SQRT_LINEAR, LCM, LCM_100, LCM_SQRT_LINEAR, # LCM_25 is purposely omitted
                   SQRT, COSINE, SQUAREDCOS_CAP_V2]
+
+    ALIAS_LIST = [AUTOSELECT, USE_EXISTING] + ALIAS_ACTIVE_LIST
+
+    
 
     ALIAS_MAP = {
         SQRT_LINEAR: "sqrt_linear",
@@ -94,11 +119,13 @@ class BetaSchedules:
         SQRT: "sqrt",
         COSINE: "cosine",
         SQUAREDCOS_CAP_V2: "squaredcos_cap_v2",
+        RAW_LINEAR: "linear",
+        RAW_SQRT_LINEAR: "sqrt_linear"
     }
 
     @classmethod
     def is_lcm(cls, alias: str):
-        return alias in cls.LCM_LIST
+        return alias in cls.ALIAS_LCM_LIST
 
     @classmethod
     def to_name(cls, alias: str):
@@ -114,24 +141,30 @@ class BetaSchedules:
         return ModelSamplingConfig(cls.to_name(alias), linear_start=linear_start, linear_end=linear_end)
     
     @classmethod
-    def to_model_sampling(cls, alias: str, model: ModelPatcher):
+    def _to_model_sampling(cls, alias: str, model_type: ModelType, config_override: ModelSamplingConfig=None, original_timesteps: int=None):
         if alias == cls.USE_EXISTING:
             return None
+        elif config_override != None:
+            return evolved_model_sampling(config_override, model_type=model_type, alias=alias, original_timesteps=original_timesteps)
         elif alias == cls.AVG_LINEAR_SQRT_LINEAR:
-            ms_linear = evolved_model_sampling(cls.to_config(cls.LINEAR), model_type=model.model.model_type, alias=cls.LINEAR)
-            ms_sqrt_linear = evolved_model_sampling(cls.to_config(cls.SQRT_LINEAR), model_type=model.model.model_type, alias=cls.SQRT_LINEAR)
+            ms_linear = evolved_model_sampling(cls.to_config(cls.LINEAR), model_type=model_type, alias=cls.LINEAR)
+            ms_sqrt_linear = evolved_model_sampling(cls.to_config(cls.SQRT_LINEAR), model_type=model_type, alias=cls.SQRT_LINEAR)
             avg_sigmas = (ms_linear.sigmas + ms_sqrt_linear.sigmas) / 2
             ms_linear.set_sigmas(avg_sigmas)
             return ms_linear
         elif alias == cls.LCM_AVG_LINEAR_SQRT_LINEAR:
-            ms_linear = evolved_model_sampling(cls.to_config(cls.LCM), model_type=model.model.model_type, alias=cls.LCM)
-            ms_sqrt_linear = evolved_model_sampling(cls.to_config(cls.LCM_SQRT_LINEAR), model_type=model.model.model_type, alias=cls.LCM_SQRT_LINEAR)
+            ms_linear = evolved_model_sampling(cls.to_config(cls.LCM), model_type=model_type, alias=cls.LCM)
+            ms_sqrt_linear = evolved_model_sampling(cls.to_config(cls.LCM_SQRT_LINEAR), model_type=model_type, alias=cls.LCM_SQRT_LINEAR)
             avg_sigmas = (ms_linear.sigmas + ms_sqrt_linear.sigmas) / 2
             ms_linear.set_sigmas(avg_sigmas)
             return ms_linear
             # average out the sigmas
-        ms_obj = evolved_model_sampling(cls.to_config(alias), model_type=model.model.model_type, alias=alias)
+        ms_obj = evolved_model_sampling(cls.to_config(alias), model_type=model_type, alias=alias, original_timesteps=original_timesteps)
         return ms_obj
+
+    @classmethod
+    def to_model_sampling(cls, alias: str, model: ModelPatcher):
+        return cls._to_model_sampling(alias=alias, model_type=model.model.model_type)
 
     @staticmethod
     def get_alias_list_with_first_element(first_element: str):
@@ -141,16 +174,65 @@ class BetaSchedules:
         return new_list
 
 
-class BetaScheduleCache:
-    def __init__(self, model: ModelPatcher): 
-        self.model_sampling = model.model.model_sampling
+class SigmaSchedule:
+    def __init__(self, model_sampling: comfy.model_sampling.ModelSamplingDiscrete, model_type: ModelType):
+        self.model_sampling = model_sampling
+        #self.config = config
+        self.model_type = model_type
+        self.original_timesteps = getattr(self.model_sampling, "original_timesteps", None)
+    
+    def is_lcm(self):
+        return self.original_timesteps is not None
 
-    def use_cached_beta_schedule_and_clean(self, model: ModelPatcher):
-        model.model.model_sampling = self.model_sampling
-        self.clean()
+    def total_sigmas(self):
+        return len(self.model_sampling.sigmas)
+    
+    def clone(self) -> 'SigmaSchedule':
+        new_model_sampling = copy.deepcopy(self.model_sampling)
+        #new_config = copy.deepcopy(self.config)
+        return SigmaSchedule(model_sampling=new_model_sampling, model_type=self.model_type)
 
-    def clean(self):
-        self.model_sampling = None
+    # def clone(self):
+    #     pass
+
+    @staticmethod
+    def apply_zsnr(new_model_sampling: comfy.model_sampling.ModelSamplingDiscrete):
+        new_model_sampling.set_sigmas(comfy_extras.nodes_model_advanced.rescale_zero_terminal_snr_sigmas(new_model_sampling.sigmas))
+
+    # def get_lcmified(self, original_timesteps=50, zsnr=False) -> 'SigmaSchedule':
+    #     new_model_sampling = evolved_model_sampling(model_config=self.config, model_type=self.model_type, alias=None, original_timesteps=original_timesteps)
+    #     if zsnr:
+    #         new_model_sampling.set_sigmas(comfy_extras.nodes_model_advanced.rescale_zero_terminal_snr_sigmas(new_model_sampling.sigmas))
+    #     return SigmaSchedule(model_sampling=new_model_sampling, config=self.config, model_type=self.model_type, is_lcm=True)
+        
+
+class InterpolationMethod:
+    LINEAR = "linear"
+    EASE_IN = "ease_in"
+    EASE_OUT = "ease_out"
+    EASE_IN_OUT = "ease_in_out"
+
+    _LIST = [LINEAR, EASE_IN, EASE_OUT, EASE_IN_OUT]
+
+    @classmethod
+    def get_weights(cls, num_from: float, num_to: float, length: int, method: str, reverse=False):
+        diff = num_to - num_from
+        if method == cls.LINEAR:
+            weights = torch.linspace(num_from, num_to, length)
+        elif method == cls.EASE_IN:
+            index = torch.linspace(0, 1, length)
+            weights = diff * np.power(index, 2) + num_from
+        elif method == cls.EASE_OUT:
+            index = torch.linspace(0, 1, length)
+            weights = diff * (1 - np.power(1 - index, 2)) + num_from
+        elif method == cls.EASE_IN_OUT:
+            index = torch.linspace(0, 1, length)
+            weights = diff * ((1 - np.cos(index * np.pi)) / 2) + num_from
+        else:
+            raise ValueError(f"Unrecognized interpolation method '{method}'.")
+        if reverse:
+            weights = weights.flip(dims=(0,))
+        return weights
 
 
 class Folders:

--- a/animatediff/utils_model.py
+++ b/animatediff/utils_model.py
@@ -14,6 +14,8 @@ from comfy.model_patcher import ModelPatcher
 import comfy.model_sampling
 import comfy_extras.nodes_model_advanced
 
+BIGMIN = -(2**63-1)
+BIGMAX = (2**63-1)
 
 class IsChangedHelper:
     def __init__(self):
@@ -238,8 +240,6 @@ def calculate_model_hash(model: ModelPatcher):
         m.update(buf.cpu().numpy().view(np.uint8))
     return m.hexdigest()
 
-BIGMIN = -(2**63-1)
-BIGMAX = (2**63-1)
 
 class ModelTypeSD:
     SD1_5 = "SD1.5"


### PR DESCRIPTION
- Standard Static Context Options now have ```relative``` Fuse Method available; works best at overlaps of at least 50% of the context length
- Custom CFG added to Sample Settings to allow per-frame, per-area, and timestep scheduling of CFG values (overrides any KSampler settings or model patches when used)
- Sigma Schedule added to Sample Settings to allow finetuning of sigma schedules beyond those of in the ```beta_schedule``` dropdown
    - For quick access, added the ```avg(sqrt_linear, linear)``` and ```lcm avg(sqrt_linear, linear)``` to the ```beta_schedule``` dropdown