### PR TITLE
Small fixes + motion lora edge case

### DIFF
--- a/animatediff/context.py
+++ b/animatediff/context.py
@@ -180,6 +180,7 @@ class ContextSchedules:
     STATIC_STANDARD = "standard_static"
     BATCHED = "batched"
     VIEW_AS_CONTEXT = "view_as_context"
+    SVD_EXTENSION = "svd_extension"
 
     LEGACY_UNIFORM_LOOPED = "uniform"
     LEGACY_UNIFORM_SCHEDULE_LIST = [LEGACY_UNIFORM_LOOPED]
@@ -302,6 +303,7 @@ CONTEXT_MAPPING = {
     ContextSchedules.UNIFORM_STANDARD: create_windows_uniform_standard,
     ContextSchedules.STATIC_STANDARD: create_windows_static_standard,
     ContextSchedules.BATCHED: create_windows_batched,
+    ContextSchedules.SVD_EXTENSION: create_windows_batched,
     ContextSchedules.VIEW_AS_CONTEXT: create_windows_default,  # just return all to allow Views to do all the work
 }
 

--- a/animatediff/model_injection.py
+++ b/animatediff/model_injection.py
@@ -341,7 +341,10 @@ def load_motion_lora_as_patches(motion_model: MotionModelPatcher, lora: MotionLo
         weight_up = state_dict[up_key]
         # actual weights obtained by matrix multiplication of up and down weights
         # save as a tuple, so that (Motion)ModelPatcher's calculate_weight function detects len==1, applying it correctly
-        patches[model_key] = (torch.mm(weight_up, weight_down),)
+        patches[model_key] = (torch.mm(
+            comfy.model_management.cast_to_device(weight_up, weight_up.device, torch.float32),
+            comfy.model_management.cast_to_device(weight_down, weight_down.device, torch.float32)
+            ),)
     del state_dict
     # add patches to motion ModelPatcher
     motion_model.add_patches(patches=patches, strength_patch=lora.strength)

--- a/animatediff/nodes_gen2.py
+++ b/animatediff/nodes_gen2.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Union
 import torch
 
 import comfy.sample as comfy_sample
@@ -201,7 +202,7 @@ class ADKeyframeNode:
 
     def load_keyframe(self,
                       start_percent: float, prev_ad_keyframes=None,
-                      scale_multival: [float, torch.Tensor]=None, effect_multival: [float, torch.Tensor]=None,
+                      scale_multival: Union[float, torch.Tensor]=None, effect_multival: Union[float, torch.Tensor]=None,
                       inherit_missing: bool=True, guarantee_steps: int=1):
         if not prev_ad_keyframes:
             prev_ad_keyframes = ADKeyframeGroup()


### PR DESCRIPTION
- Ensure weight_up and weight_down are cast to torch.float32 before torch.mm call (half types not supported for torch.mm)
- Fix type annotation for scale/effect multival (does not impact code, but should have had a Union)
- Experimental support for context windows for SVD - don't really work well, so I'm not exposing it, but at least I properly modify num_video_frames in conds for SVD in the case that I ever do expose it