### PR TITLE
fix admd lora keys

### DIFF
--- a/animatediff/model_injection.py
+++ b/animatediff/model_injection.py
@@ -334,8 +334,10 @@ def load_motion_lora_as_patches(motion_model: MotionModelPatcher, lora: MotionLo
 
         # adapt key to match motion_module key format - remove 'processor.', '_lora', 'down.', and 'up.'
         model_key = key.replace("processor.", "").replace("_lora", "").replace("down.", "").replace("up.", "")
+
         # motion_module keys have a '0.' after all 'to_out.' weight keys
-        model_key = model_key.replace("to_out.", "to_out.0.")
+        if "to_out.0." not in model_key:
+            model_key = model_key.replace("to_out.", "to_out.0.")
         
         weight_down = state_dict[key]
         weight_up = state_dict[up_key]


### PR DESCRIPTION
The motion loras that we've been training with the ADMD training repo and custom nodes are saved with 'to_out.0.' in the weight keys. This PR checks if that's the case before replacing 'to_out.' with 'to_out.0.' to prevent it from becoming 'to_out.0.0.'