### PR TITLE
Added some new methods for context window weight generation

### DIFF
--- a/animatediff/context.py
+++ b/animatediff/context.py
@@ -11,9 +11,14 @@ class ContextFuseMethod:
     FLAT = "flat"
     PYRAMID = "pyramid"
     RELATIVE = "relative"
-
-    LIST = [PYRAMID, FLAT]
-    LIST_STATIC = [PYRAMID, RELATIVE, FLAT]
+    RANDOM = "random"
+    GAUSS_SIGMA = "gauss-sigma"
+    GAUSS_SIGMA_INV = "gauss-sigma inverse"
+    TEMPORAL_EDGE = "temporal edge"
+    PYRAMID_SIGMA = "pyramid-sigma"
+    PYRAMID_SIGMA_INV = "pyramid-sigma inverse"
+    LIST = [PYRAMID, FLAT, PYRAMID_SIGMA, PYRAMID_SIGMA_INV, GAUSS_SIGMA, GAUSS_SIGMA_INV, RANDOM, TEMPORAL_EDGE ]
+    LIST_STATIC = [PYRAMID, RELATIVE, FLAT, PYRAMID_SIGMA, PYRAMID_SIGMA_INV, GAUSS_SIGMA, GAUSS_SIGMA_INV, RANDOM, TEMPORAL_EDGE]
 
 
 class ContextType:
@@ -308,17 +313,16 @@ CONTEXT_MAPPING = {
 }
 
 
-def get_context_weights(num_frames: int, fuse_method: str):
+def get_context_weights(num_frames: int, fuse_method: str, sigma: Tensor = None):
     weights_func = FUSE_MAPPING.get(fuse_method, None)
     if not weights_func:
         raise ValueError(f"Unknown fuse_method '{fuse_method}'.")
-    return weights_func(num_frames)
+    return weights_func(num_frames, sigma=sigma )
 
 
 def create_weights_flat(length: int, **kwargs) -> list[float]:
     # weight is the same for all
     return [1.0] * length
-
 
 def create_weights_pyramid(length: int, **kwargs) -> list[float]:
     # weight is based on the distance away from the edge of the context window;
@@ -331,11 +335,91 @@ def create_weights_pyramid(length: int, **kwargs) -> list[float]:
         weight_sequence = list(range(1, max_weight, 1)) + [max_weight] + list(range(max_weight - 1, 0, -1))
     return weight_sequence
 
+def create_weights_random(length: int, **kwargs) -> list[float]:
+    if length % 2 == 0:
+        max_weight = length // 2
+    else:
+        max_weight = (length + 1) // 2
+    return list(np.random.random(length)*max_weight+0.001)
+    
+def create_weights_gauss_sigma(length: int, **kwargs) -> list[float]:
+    sigma = 1.0 + 8.0*(min(4.0, kwargs["sigma"].mean().cpu()) / 4.0)
+    ax = np.linspace(-(length - 1) / 2., (length - 1) / 2., length)
+    w = np.exp(-0.5 * np.square(ax) / np.square(sigma))
+    if length % 2 == 0:
+        max_weight = length // 2
+    else:
+        max_weight = (length + 1) // 2
+    w *= max_weight / np.linalg.norm(w)
+    print("create_weights_gauss_sigma sigma",sigma,w)
+    return list(w)
+    
+def create_weights_gauss_sigma_inv(length: int, **kwargs) -> list[float]:
+    sigma = 1.0 + 8.0*(1.0-min(4.0, kwargs["sigma"].mean().cpu()) / 4.0)
+    ax = np.linspace(-(length - 1) / 2., (length - 1) / 2., length)
+    w = np.exp(-0.5 * np.square(ax) / np.square(sigma))
+    if length % 2 == 0:
+        max_weight = length // 2
+    else:
+        max_weight = (length + 1) // 2
+    w *= max_weight / np.linalg.norm(w)
+    print("create_weights_gauss_sigma_inv sigma",sigma,w)
+    return list(w)
+
+def create_weights_pyramid_sigma_inv(length: int, **kwargs) -> list[float]:
+    sigma = min(4.0, kwargs["sigma"].mean().cpu()) / 4.0
+    
+    if length % 2 == 0:
+        max_weight = length // 2
+        weight_sequence = np.array(list(range(1, max_weight + 1, 1)) + list(range(max_weight, 0, -1)))
+        weight_sequence2 = np.array([-max_weight]*(max_weight-1) +[max_weight,max_weight] + [-max_weight]*(max_weight-1))
+    else:
+        max_weight = (length + 1) // 2
+        weight_sequence = list(range(1, max_weight, 1)) + [max_weight] + list(range(max_weight - 1, 0, -1))
+        weight_sequence2 = np.array([-max_weight]*(max_weight) +[max_weight] + [-max_weight]*(max_weight-1))
+    weight_sequence = (sigma * weight_sequence2 + (1.0-sigma) * weight_sequence).clip(0.001,max_weight)
+    #print("create_weights_pyramid_sigma_inv",kwargs["sigma"].mean(),sigma, len(weight_sequence),weight_sequence)
+      
+    return list(weight_sequence)
+
+def create_weights_pyramid_sigma(length: int, **kwargs) -> list[float]:
+    sigma = min(4.0, kwargs["sigma"].mean().cpu()) / 4.0
+    
+    if length % 2 == 0:
+        max_weight = length // 2
+        weight_sequence = np.array(list(range(1, max_weight + 1, 1)) + list(range(max_weight, 0, -1)))
+        weight_sequence2 = np.array([-max_weight]*(max_weight-1) +[max_weight,max_weight] + [-max_weight]*(max_weight-1))
+    else:
+        max_weight = (length + 1) // 2
+        weight_sequence = list(range(1, max_weight, 1)) + [max_weight] + list(range(max_weight - 1, 0, -1))
+        weight_sequence2 = np.array([-max_weight]*(max_weight) +[max_weight] + [-max_weight]*(max_weight-1))
+    weight_sequence = (sigma * weight_sequence + (1.0-sigma) * weight_sequence2).clip(0.001,max_weight)
+    #print("create_weights_pyramid_sigma",kwargs["sigma"].mean(),sigma, len(weight_sequence),weight_sequence)
+      
+    return list(weight_sequence)
+
+def create_weights_temporal_edge(length: int, **kwargs) -> list[float]:
+    if length % 2 == 0:
+        max_weight = length // 2
+        weight_sequence = [0.01]*(max_weight-1) + [max_weight] + list(range(max_weight, 0, -1))
+    else:
+        max_weight = (length + 1) // 2
+        weight_sequence = [0.01]*max_weight + [max_weight] + list(range(max_weight - 1, 0, -1))
+    
+    #print("create_weights_temporal_edge",len(weight_sequence),weight_sequence)
+    return weight_sequence
+
 
 FUSE_MAPPING = {
     ContextFuseMethod.FLAT: create_weights_flat,
     ContextFuseMethod.PYRAMID: create_weights_pyramid,
     ContextFuseMethod.RELATIVE: create_weights_pyramid,
+    ContextFuseMethod.GAUSS_SIGMA: create_weights_gauss_sigma,
+    ContextFuseMethod.GAUSS_SIGMA_INV: create_weights_gauss_sigma_inv,
+    ContextFuseMethod.RANDOM: create_weights_random,
+    ContextFuseMethod.TEMPORAL_EDGE: create_weights_temporal_edge,
+    ContextFuseMethod.PYRAMID_SIGMA: create_weights_pyramid_sigma,
+    ContextFuseMethod.PYRAMID_SIGMA_INV: create_weights_pyramid_sigma_inv,
 }
 
 

--- a/animatediff/sampling.py
+++ b/animatediff/sampling.py
@@ -609,7 +609,7 @@ def sliding_calc_conds_batch(model, conds, x_in: Tensor, timestep, model_options
                         biases_final[i][(full_length*n)+idx] = bias_total + bias
         else:
             # add conds and counts based on weights of fuse method
-            weights = get_context_weights(len(ctx_idxs), ADGS.params.context_options.fuse_method) * batched_conds
+            weights = get_context_weights(len(ctx_idxs), ADGS.params.context_options.fuse_method, sigma=timestep) * batched_conds
             weights_tensor = torch.Tensor(weights).to(device=x_in.device).unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
             for i in range(len(sub_conds_out)):
                 conds_final[i][full_idxs] += sub_conds_out[i] * weights_tensor


### PR DESCRIPTION
There seems to be some interesting potential for experimentation in the weights for the context window, right now there is only flat and pyramid and they are identical for every step.

This pull request adds a few new shapes for the weights, but also introduces a new feature: by passing in the sigma it is possible to change the weights over time and for example have a stronger weight for the center conditionings at the beginning which then gradually smooths out towards the end. Or vice-versal.