### PR TITLE
Implement a deprecation widget which also hides nodes from the search box

### DIFF
--- a/animatediff/nodes_deprecated.py
+++ b/animatediff/nodes_deprecated.py
@@ -30,6 +30,7 @@ class AnimateDiffLoader_Deprecated:
                 "unlimited_area_hack": ("BOOLEAN", {"default": False},),
                 "beta_schedule": (BetaSchedules.get_alias_list_with_first_element(BetaSchedules.SQRT_LINEAR),),
             },
+            "optional": {"deprecation_warning": ("ADEWARN", {"text": "Deprecated"})},
         }
 
     RETURN_TYPES = ("MODEL", "LATENT")
@@ -86,6 +87,7 @@ class AnimateDiffLoaderAdvanced_Deprecated:
                 "closed_loop": ("BOOLEAN", {"default": False},),
                 "beta_schedule": (BetaSchedules.get_alias_list_with_first_element(BetaSchedules.SQRT_LINEAR),),
             },
+            "optional": {"deprecation_warning": ("ADEWARN", {"text": "Deprecated"})},
         }
 
     RETURN_TYPES = ("MODEL", "LATENT")
@@ -166,6 +168,7 @@ class AnimateDiffCombine_Deprecated:
                 "pingpong": ("BOOLEAN", {"default": False}),
                 "save_image": ("BOOLEAN", {"default": True}),
             },
+            "optional": {"deprecation_warning": ("ADEWARN", {"text": "Deprecated. Use VHS Video Combine"})},
             "hidden": {
                 "prompt": "PROMPT",
                 "extra_pnginfo": "EXTRA_PNGINFO",

--- a/animatediff/nodes_pia.py
+++ b/animatediff/nodes_pia.py
@@ -164,6 +164,7 @@ class LoadAnimateDiffAndInjectPIANode:
             },
             "optional": {
                 "ad_settings": ("AD_SETTINGS",),
+                "deprecation_warning": ("ADEWARN", {"text": "Experimental. Don't expect to work", "warn_type": "experimental", "color": "#CFC"}),
             }
         }
     

--- a/web/js/deprecate_nodes.js
+++ b/web/js/deprecate_nodes.js
@@ -1,0 +1,70 @@
+import { app } from '../../../scripts/app.js'
+
+const deprecate_nodes = {
+    name: 'AnimateDiff.deprecate_nodes',
+    async setup() {
+        if (app.graph.filter) {
+            //Someone else is doing a thing. Give up
+            return
+        }
+        for (let k in LiteGraph.registered_node_types) {
+            let n = LiteGraph.registered_node_types[k]
+            let warnWidget = false
+            if (n?.nodeData?.input?.optional) {
+                for (let w in n.nodeData.input.optional) {
+                    if (n.nodeData.input.optional[w][0] == "ADEWARN") {
+                        warnWidget = true
+                        break
+                    }
+                }
+            }
+            if (warnWidget) {
+                n.filter = "hidden"
+                continue
+            }
+            if (!n.filter) {
+                n.filter = "shown"
+            }
+        }
+        app.graph.filter = "shown"
+    },
+    async getCustomWidgets() {
+        return {
+            ADEWARN(node, inputName, inputData) {
+                let w = {
+                    name : inputName,
+                    type : "ADE.WARN",
+                    value : "",
+                    draw : function(ctx, node, widget_width, y, H) {
+                        var show_text = app.canvas.ds.scale > 0.5;
+                        var margin = 15;
+                        var text_color = "#FCC"
+                        ctx.textAlign = "center";
+                        if (show_text) {
+                            if(!this.disabled)
+                                ctx.stroke();
+                            ctx.save();
+                            ctx.beginPath();
+                            ctx.rect(margin, y, widget_width - margin * 2, H);
+                            ctx.clip();
+                            ctx.fillStyle = text_color;
+                            let disp_text = inputData[1]['text']
+                            ctx.fillText(disp_text, widget_width/2, y + H * 0.7); //30 chars max
+                            ctx.restore();
+                        }
+
+                    },
+                    options : {}
+                }
+                if (!node.widgets) {
+                    node.widgets = []
+                }
+                node.widgets.push(w)
+                return w
+            }
+        }
+    }
+}
+
+app.registerExtension(deprecate_nodes)
+

--- a/web/js/deprecate_nodes.js
+++ b/web/js/deprecate_nodes.js
@@ -28,6 +28,7 @@ const deprecate_nodes = {
         }
         app.graph.filter = "shown"
     },
+    async refreshComboInNodes: () => app.graph.filter = "shown",
     async getCustomWidgets() {
         return {
             ADEWARN(node, inputName, inputData) {

--- a/web/js/deprecate_nodes.js
+++ b/web/js/deprecate_nodes.js
@@ -54,7 +54,7 @@ const deprecate_nodes = {
                         }
 
                     },
-                    options : {}
+                    options : {"serialize": false}
                 }
                 if (!node.widgets) {
                     node.widgets = []


### PR DESCRIPTION
Implements a new ADEWARN widget which displays red warning text on a node. Nodes which have an ADEWARN widget are hidden from the searchbox.

The method for hiding nodes from the search box is a bit heavier than I would like, but the implementation allows for you to add warnings and hide nodes without touching JS.

EDIT: Also hides from "Add Node" Menu. Currently investigating if only search box can be filtered for experimental nodes

EDIT2: Also fails to reassign filter after the "Refresh" button is clicked, which results in all non clientside nodes being hidden until a proper refresh