### PR TITLE
Version bump for .js fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-animatediff-evolved"
 description = "Improved AnimateDiff integration for ComfyUI."
-version = "1.0.7"
+version = "1.0.8"
 license = "LICENSE"
 dependencies = []
 


### PR DESCRIPTION
Making sure that it will be easier to track down the issue for anyone who might have pulled 1.0.7 and didnt update to anything newer that doesnt have the issue that breaks rgthree and some other nodes from being found in menu/searchbar.