### PR TITLE
Visualize Context Options nodes

### DIFF
--- a/animatediff/context.py
+++ b/animatediff/context.py
@@ -1,8 +1,7 @@
-from typing import Callable, Optional, Union
+from typing import Union
 
 import torch
 import torchvision
-import PIL
 from PIL import Image, ImageFont, ImageDraw
 
 import numpy as np

--- a/animatediff/context.py
+++ b/animatediff/context.py
@@ -616,6 +616,8 @@ def generate_context_visualization(context_opts: ContextOptionsGroup, model: Mod
 
     if start_step is None:
         start_step = 0  # use this in case start_step is provided, to display accurate step
+    if steps is None:
+        steps = len(sigmas)
 
     for i, t in enumerate(sigmas):
         # make context_opts reflect current step/sigma
@@ -674,5 +676,5 @@ def generate_context_visualization(context_opts: ContextOptionsGroup, model: Mod
                 repeat_count += 1
 
     images = torch.stack(all_imgs)
-    images = images.movedim(1, -1)
+    images = images.movedim(1, -1).to(torch.float32)
     return images

--- a/animatediff/nodes.py
+++ b/animatediff/nodes.py
@@ -25,7 +25,8 @@ from .nodes_sample import (FreeInitOptionsNode, NoiseLayerAddWeightedNode, Sampl
                            NoisedImageInjectionNode, NoisedImageInjectOptionsNode)
 from .nodes_sigma_schedule import (SigmaScheduleNode, RawSigmaScheduleNode, WeightedAverageSigmaScheduleNode, InterpolatedWeightedAverageSigmaScheduleNode, SplitAndCombineSigmaScheduleNode)
 from .nodes_context import (LegacyLoopedUniformContextOptionsNode, LoopedUniformContextOptionsNode, LoopedUniformViewOptionsNode, StandardUniformContextOptionsNode, StandardStaticContextOptionsNode, BatchedContextOptionsNode,
-                            StandardStaticViewOptionsNode, StandardUniformViewOptionsNode, ViewAsContextOptionsNode, VisualizeContextOptionsInt)
+                            StandardStaticViewOptionsNode, StandardUniformViewOptionsNode, ViewAsContextOptionsNode,
+                            VisualizeContextOptionsK, VisualizeContextOptionsKAdv, VisualizeContextOptionsSCustom)
 from .nodes_ad_settings import (AnimateDiffSettingsNode, ManualAdjustPENode, SweetspotStretchPENode, FullStretchPENode,
                                 WeightAdjustAllAddNode, WeightAdjustAllMultNode, WeightAdjustIndivAddNode, WeightAdjustIndivMultNode,
                                 WeightAdjustIndivAttnAddNode, WeightAdjustIndivAttnMultNode)
@@ -58,7 +59,9 @@ NODE_CLASS_MAPPINGS = {
     "ADE_ViewsOnlyContextOptions": ViewAsContextOptionsNode,
     "ADE_BatchedContextOptions": BatchedContextOptionsNode,
     "ADE_AnimateDiffUniformContextOptions": LegacyLoopedUniformContextOptionsNode, # Legacy
-    #"ADE_VisualizeContextOptions": VisualizeContextOptionsInt,
+    "ADE_VisualizeContextOptionsK": VisualizeContextOptionsK,
+    "ADE_VisualizeContextOptionsKAdv": VisualizeContextOptionsKAdv,
+    "ADE_VisualizeContextOptionsSCustom": VisualizeContextOptionsSCustom,
     # View Opts
     "ADE_StandardStaticViewOptions": StandardStaticViewOptionsNode,
     "ADE_StandardUniformViewOptions": StandardUniformViewOptionsNode,
@@ -180,7 +183,9 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ADE_ViewsOnlyContextOptions": "Context Options◆Views Only [VRAM⇈] 🎭🅐🅓",
     "ADE_BatchedContextOptions": "Context Options◆Batched [Non-AD] 🎭🅐🅓",
     "ADE_AnimateDiffUniformContextOptions": "Context Options◆Looped Uniform 🎭🅐🅓", # Legacy
-    "ADE_VisualizeContextOptions": "Visualize Context Options 🎭🅐🅓",
+    "ADE_VisualizeContextOptionsK": "Visualize Context Options (K.) 🎭🅐🅓",
+    "ADE_VisualizeContextOptionsKAdv": "Visualize Context Options (K.Adv.) 🎭🅐🅓",
+    "ADE_VisualizeContextOptionsSCustom": "Visualize Context Options (S.Cus.) 🎭🅐🅓",
     # View Opts
     "ADE_StandardStaticViewOptions": "View Options◆Standard Static 🎭🅐🅓",
     "ADE_StandardUniformViewOptions": "View Options◆Standard Uniform 🎭🅐🅓",

--- a/animatediff/nodes_context.py
+++ b/animatediff/nodes_context.py
@@ -1,10 +1,12 @@
 import torch
 from torch import Tensor
 
+import comfy.samplers
 from comfy.model_patcher import ModelPatcher
 
-from .context import ContextFuseMethod, ContextOptions, ContextOptionsGroup, ContextSchedules
-from .utils_model import BIGMAX
+from .context import (ContextFuseMethod, ContextOptions, ContextOptionsGroup, ContextSchedules,
+                      generate_context_visualization)
+from .utils_model import BIGMAX, MAX_RESOLUTION
 
 
 LENGTH_MAX = 128   # keep an eye on these max values;
@@ -353,16 +355,20 @@ class LoopedUniformViewOptionsNode:
         return (view_options,)
 
 
-class VisualizeContextOptionsInt:
+class VisualizeContextOptionsKAdv:
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
                 "model": ("MODEL",),
                 "context_opts": ("CONTEXT_OPTIONS",),
+                "sampler_name": (comfy.samplers.KSampler.SAMPLERS, ),
+                "scheduler": (comfy.samplers.KSampler.SCHEDULERS, ),
             },
             "optional": {
+                "visual_width": ("INT", {"min": 32, "max": MAX_RESOLUTION, "default": 1440}),
                 "latents_length": ("INT", {"min": 1, "max": BIGMAX, "default": 32}),
+                "steps": ("INT", {"min": 0, "max": BIGMAX, "default": 20}),
                 "start_step": ("INT", {"min": 0, "max": BIGMAX, "default": 0}),
                 "end_step": ("INT", {"min": 1, "max": BIGMAX, "default": 20}),
             }
@@ -372,7 +378,65 @@ class VisualizeContextOptionsInt:
     CATEGORY = "Animate Diff 🎭🅐🅓/context opts/visualize"
     FUNCTION = "visualize"
 
-    def visualize(self, model: ModelPatcher, context_opts: ContextOptionsGroup,
-                  latents_length=32, start_step=0, end_step=20):
-        images = torch.zeros((latents_length, 256, 256, 3))
+    def visualize(self, model: ModelPatcher, context_opts: ContextOptionsGroup, sampler_name: str, scheduler: str,
+                  visual_width: 1280, latents_length=32, steps=20, start_step=0, end_step=20):
+        images = generate_context_visualization(context_opts=context_opts, model=model, width=visual_width, video_length=latents_length,
+                                                sampler_name=sampler_name, scheduler=scheduler,
+                                                steps=steps, start_step=start_step, end_step=end_step)
+        return (images,)
+
+
+class VisualizeContextOptionsK:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "context_opts": ("CONTEXT_OPTIONS",),
+                "sampler_name": (comfy.samplers.KSampler.SAMPLERS, ),
+                "scheduler": (comfy.samplers.KSampler.SCHEDULERS, ),
+            },
+            "optional": {
+                "visual_width": ("INT", {"min": 32, "max": MAX_RESOLUTION, "default": 1440}),
+                "latents_length": ("INT", {"min": 1, "max": BIGMAX, "default": 32}),
+                "steps": ("INT", {"min": 0, "max": BIGMAX, "default": 20}),
+                "denoise": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+            }
+        }
+    
+    RETURN_TYPES = ("IMAGE",)
+    CATEGORY = "Animate Diff 🎭🅐🅓/context opts/visualize"
+    FUNCTION = "visualize"
+
+    def visualize(self, model: ModelPatcher, context_opts: ContextOptionsGroup, sampler_name: str, scheduler: str,
+                  visual_width: 1280, latents_length=32, steps=20, denoise=1.0):
+        images = generate_context_visualization(context_opts=context_opts, model=model, width=visual_width, video_length=latents_length,
+                                                sampler_name=sampler_name, scheduler=scheduler,
+                                                steps=steps, denoise=denoise)
+        return (images,)
+
+
+class VisualizeContextOptionsSCustom:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "context_opts": ("CONTEXT_OPTIONS",),
+                "sigmas": ("SIGMAS", ),
+            },
+            "optional": {
+                "visual_width": ("INT", {"min": 32, "max": MAX_RESOLUTION, "default": 1440}),
+                "latents_length": ("INT", {"min": 1, "max": BIGMAX, "default": 32}),
+            }
+        }
+    
+    RETURN_TYPES = ("IMAGE",)
+    CATEGORY = "Animate Diff 🎭🅐🅓/context opts/visualize"
+    FUNCTION = "visualize"
+
+    def visualize(self, model: ModelPatcher, context_opts: ContextOptionsGroup, sigmas,
+                  visual_width: 1280, latents_length=32):
+        images = generate_context_visualization(context_opts=context_opts, model=model, width=visual_width, video_length=latents_length,
+                                                sigmas=sigmas)
         return (images,)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-animatediff-evolved"
 description = "Improved AnimateDiff integration for ComfyUI."
-version = "1.0.9"
+version = "1.0.10"
 license = "LICENSE"
 dependencies = []
 


### PR DESCRIPTION
- Visualize Context Options nodes to visualize Context Options + View Options, including scheduled Context Options.
- View Options now get assigned the step properly, changing the results of Uniform View Options (looped and standard). I don't think anyone was trying to use those anyway, so the fact the results change should not be an issue. Will consider adding a toggle if I get complaints.