### PR TITLE
Fix regression with scale float list/mask multival + contexts

### DIFF
--- a/animatediff/motion_module_ad.py
+++ b/animatediff/motion_module_ad.py
@@ -920,6 +920,7 @@ class TemporalTransformer3DModel(nn.Module):
         self.temp_cameractrl_effect = None
 
     def set_sub_idxs(self, sub_idxs: list[int]):
+        self.sub_idxs = sub_idxs
         for block in self.transformer_blocks:
             block.set_sub_idxs(sub_idxs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-animatediff-evolved"
 description = "Improved AnimateDiff integration for ComfyUI."
-version = "1.1.3"
+version = "1.1.4"
 license = { file = "LICENSE" }
 dependencies = []
 


### PR DESCRIPTION
While working on the last update, I was exploring moving scale_masks creation into a deeper level, and ended up undoing my changes. However, I forgot to bring back the line that sets self.sub_idxs, so it broke scale masks for context windows.