### PR TITLE
Work with new ComfyUI ModelPatcher update (NOT backwards compatible)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-animatediff-evolved"
 description = "Improved AnimateDiff integration for ComfyUI."
-version = "1.1.4"
+version = "1.2.0"
 license = { file = "LICENSE" }
 dependencies = []
 


### PR DESCRIPTION
ModelPatcher changed in ComfyUI, so I had to implement the proper changes. Due to the change in logic, the code will no longer work with previous versions of ComfyUI.

This also gave me the opportunity to delete a bunch of old code snippets I had to have in code for backwards compatibility so the code is a bit cleaner.

After merging this, I will do the same for SparseCtrl in Advanced-ControlNet.