### PR TITLE
Fix Gen1 Nodes scale/effect/per_block, deprecate LoRA Hook Keyframes Interp. node

### DIFF
--- a/animatediff/nodes.py
+++ b/animatediff/nodes.py
@@ -11,7 +11,7 @@ from .nodes_cameractrl import (LoadAnimateDiffModelWithCameraCtrl, ApplyAnimateD
 from .nodes_pia import (ApplyAnimateDiffPIAModel, LoadAnimateDiffAndInjectPIANode, InputPIA_MultivalNode, InputPIA_PaperPresetsNode, PIA_ADKeyframeNode)
 from .nodes_fancyvideo import (ApplyAnimateDiffFancyVideo,)
 from .nodes_multival import MultivalDynamicNode, MultivalScaledMaskNode, MultivalDynamicFloatInputNode, MultivalDynamicFloatsNode, MultivalConvertToMaskNode
-from .nodes_conditioning import (CreateLoraHookKeyframeInterpolation,
+from .nodes_conditioning import (CreateLoraHookKeyframeInterpolationDEPR,
                                  MaskableLoraLoaderDEPR, MaskableLoraLoaderModelOnlyDEPR, MaskableSDModelLoaderDEPR, MaskableSDModelLoaderModelOnlyDEPR, 
                                  SetModelLoraHookDEPR, SetClipLoraHookDEPR,
                                  CombineLoraHooksDEPR, CombineLoraHookFourOptionalDEPR, CombineLoraHookEightOptionalDEPR,
@@ -98,7 +98,6 @@ NODE_CLASS_MAPPINGS = {
     "ADE_IterationOptsDefault": IterationOptionsNode,
     "ADE_IterationOptsFreeInit": FreeInitOptionsNode,
     # Conditioning
-    "ADE_LoraHookKeyframeInterpolation": CreateLoraHookKeyframeInterpolation,
     # Conditioning (DEPRECATED)
     "ADE_RegisterLoraHook": MaskableLoraLoaderDEPR,
     "ADE_RegisterLoraHookModelOnly": MaskableLoraLoaderModelOnlyDEPR,
@@ -110,6 +109,7 @@ NODE_CLASS_MAPPINGS = {
     "ADE_SetLoraHookKeyframe": SetLoraHookKeyframesDEPR,
     "ADE_AttachLoraHookToCLIP": SetClipLoraHookDEPR,
     "ADE_LoraHookKeyframe": CreateLoraHookKeyframeDEPR,
+    "ADE_LoraHookKeyframeInterpolation": CreateLoraHookKeyframeInterpolationDEPR,
     "ADE_LoraHookKeyframeFromStrengthList": CreateLoraHookKeyframeFromStrengthListDEPR,
     "ADE_AttachLoraHookToConditioning": SetModelLoraHookDEPR,
     "ADE_PairedConditioningSetMask": PairedConditioningSetMaskHookedDEPR,
@@ -269,7 +269,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ADE_IterationOptsDefault": "Default Iteration Options 🎭🅐🅓",
     "ADE_IterationOptsFreeInit": "FreeInit Iteration Options 🎭🅐🅓",
     # Conditioning
-    "ADE_LoraHookKeyframeInterpolation": "LoRA Hook Keyframes Interp. 🎭🅐🅓",
     # Conditioning (DEPRECATED)
     "ADE_RegisterLoraHook": "Register LoRA Hook 🎭🅐🅓",
     "ADE_RegisterLoraHookModelOnly": "Register LoRA Hook (Model Only) 🎭🅐🅓",
@@ -281,6 +280,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ADE_SetLoraHookKeyframe": "Set LoRA Hook Keyframes 🎭🅐🅓",
     "ADE_AttachLoraHookToCLIP": "Set CLIP LoRA Hook 🎭🅐🅓",
     "ADE_LoraHookKeyframe": "LoRA Hook Keyframe 🎭🅐🅓",
+    "ADE_LoraHookKeyframeInterpolation": "LoRA Hook Keyframes Interp. 🎭🅐🅓",
     "ADE_LoraHookKeyframeFromStrengthList": "LoRA Hook Keyframes From List 🎭🅐🅓",
     "ADE_AttachLoraHookToConditioning": "Set Model LoRA Hook 🎭🅐🅓",
     "ADE_PairedConditioningSetMask": "Set Props on Conds 🎭🅐🅓",

--- a/animatediff/nodes_conditioning.py
+++ b/animatediff/nodes_conditioning.py
@@ -17,7 +17,15 @@ from .utils_model import BIGMAX, InterpolationMethod
 from .logger import logger
 
 
-class CreateLoraHookKeyframeInterpolation:
+###################################################################
+# EVERYTHING BELOW HERE IS DEPRECATED;
+# Can be replaced with vanilla ComfyUI nodes
+#------------------------------------------------------------------
+#------------------------------------------------------------------
+#------------------------------------------------------------------
+#------------------------------------------------------------------
+#------------------------------------------------------------------
+class CreateLoraHookKeyframeInterpolationDEPR:
     @classmethod
     def INPUT_TYPES(s):
         return {
@@ -32,12 +40,14 @@ class CreateLoraHookKeyframeInterpolation:
             },
             "optional": {
                 "prev_hook_kf": ("HOOK_KEYFRAMES",),
+                "deprecation_warning": ("ADEWARN", {"text": "Deprecated - use native ComfyUI nodes instead."}),
             },
             "hidden": {
                 "autosize": ("ADEAUTOSIZE", {"padding": 0}),
             }
         }
     
+    DEPRECATED = True
     RETURN_TYPES = ("HOOK_KEYFRAMES",)
     RETURN_NAMES = ("HOOK_KF",)
     CATEGORY = "Animate Diff 🎭🅐🅓/conditioning/schedule lora hooks"
@@ -64,18 +74,6 @@ class CreateLoraHookKeyframeInterpolation:
             if print_keyframes:
                 logger.info(f"HookKeyframe - start_percent:{percent} = {strength}")
         return (prev_hook_kf,)
-
-
-
-###################################################################
-# EVERYTHING BELOW HERE IS DEPRECATED;
-# Can be replaced with vanilla ComfyUI nodes
-#------------------------------------------------------------------
-#------------------------------------------------------------------
-#------------------------------------------------------------------
-#------------------------------------------------------------------
-#------------------------------------------------------------------
-
 
 
 ###############################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-animatediff-evolved"
 description = "Improved AnimateDiff integration for ComfyUI."
-version = "1.3.2"
+version = "1.3.3"
 license = { file = "LICENSE" }
 dependencies = []
 


### PR DESCRIPTION
I made a native ComfyUI node that got merged into ComfyUI, so the LoRA Hook Keyframes Interp. is now deprecated in favor of it.