### PR TITLE
Add normalized weighted sum noise layer

### DIFF
--- a/animatediff/nodes.py
+++ b/animatediff/nodes.py
@@ -23,7 +23,7 @@ from .nodes_conditioning import (CreateLoraHookKeyframeInterpolationDEPR,
                                  PairedConditioningCombineDEPR, ConditioningCombineDEPR,
                                  ConditioningTimestepsNodeDEPR, SetLoraHookKeyframesDEPR,
                                  CreateLoraHookKeyframeDEPR, CreateLoraHookKeyframeFromStrengthListDEPR)
-from .nodes_sample import (FreeInitOptionsNode, NoiseLayerAddWeightedNode, SampleSettingsNode, NoiseLayerAddNode, NoiseLayerReplaceNode, IterationOptionsNode,
+from .nodes_sample import (FreeInitOptionsNode, NoiseLayerAddWeightedNode, NoiseLayerNormalizedSumNode, SampleSettingsNode, NoiseLayerAddNode, NoiseLayerReplaceNode, IterationOptionsNode,
                            CustomCFGNode, CustomCFGSimpleNode, CustomCFGKeyframeNode, CustomCFGKeyframeSimpleNode, CustomCFGKeyframeInterpolationNode, CustomCFGKeyframeFromListNode,
                            CFGExtrasPAGNode, CFGExtrasPAGSimpleNode, CFGExtrasRescaleCFGNode, CFGExtrasRescaleCFGSimpleNode,
                            NoisedImageInjectionNode, NoisedImageInjectOptionsNode, NoiseCalibrationNode)
@@ -126,6 +126,7 @@ NODE_CLASS_MAPPINGS = {
     # Noise Layer Nodes
     "ADE_NoiseLayerAdd": NoiseLayerAddNode,
     "ADE_NoiseLayerAddWeighted": NoiseLayerAddWeightedNode,
+    "ADE_NoiseLayerNormalizedSum": NoiseLayerNormalizedSumNode,
     "ADE_NoiseLayerReplace": NoiseLayerReplaceNode,
     # AnimateDiff Settings
     "ADE_AnimateDiffSettings": AnimateDiffSettingsNode,
@@ -304,6 +305,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     # Noise Layer Nodes
     "ADE_NoiseLayerAdd": "Noise Layer [Add] 🎭🅐🅓",
     "ADE_NoiseLayerAddWeighted": "Noise Layer [Add Weighted] 🎭🅐🅓",
+    "ADE_NoiseLayerNormalizedSum": "Noise Layer [Normalized Sum] 🎭🅐🅓",
     "ADE_NoiseLayerReplace": "Noise Layer [Replace] 🎭🅐🅓",
     # AnimateDiff Settings
     "ADE_AnimateDiffSettings": "AnimateDiff Settings 🎭🅐🅓",

--- a/animatediff/sample_settings.py
+++ b/animatediff/sample_settings.py
@@ -171,7 +171,8 @@ class NoiseLayerAdd(NoiseLayer):
 class NoiseLayerAddWeighted(NoiseLayerAdd):
     def __init__(self, noise_type: str, batch_offset: int, seed_gen_override: str, seed_offset: int, seed_override: int=None, mask: Tensor=None,
                  noise_weight=1.0, balance_multiplier=1.0):
-        super().__init__(noise_type, batch_offset, seed_gen_override, seed_offset, seed_override, mask, noise_weight)
+        super().__init__(noise_type, batch_offset, seed_gen_override, seed_offset, seed_override, mask)
+        self.noise_weight = noise_weight
         self.balance_multiplier = balance_multiplier
         self.application = NoiseApplication.ADD_WEIGHTED
 
@@ -183,7 +184,7 @@ class NoiseLayerAddWeighted(NoiseLayerAdd):
 class NoiseLayerNormalizedSum(NoiseLayer):
     def __init__(self, noise_type: str, batch_offset: int, seed_gen_override: str, seed_offset: int, seed_override: int=None, mask: Tensor=None,
                  noise_weight=1.0):
-        super().__init__(noise_type, batch_offset, seed_gen_override, seed_offset, seed_override, mask, noise_weight)
+        super().__init__(noise_type, batch_offset, seed_gen_override, seed_offset, seed_override, mask)
         self.noise_weight = noise_weight
         self.application = NoiseApplication.NORMALIZED_SUM
 

--- a/animatediff/sample_settings.py
+++ b/animatediff/sample_settings.py
@@ -185,7 +185,7 @@ class NoiseLayerNormalizedSum(NoiseLayer):
                  noise_weight=1.0):
         super().__init__(noise_type, batch_offset, seed_gen_override, seed_offset, seed_override, mask, noise_weight)
         self.noise_weight = noise_weight
-        self.application = NoiseApplication.ADD_WEIGHTED
+        self.application = NoiseApplication.NORMALIZED_SUM
 
     def apply_layer_noise(self, new_noise: Tensor, old_noise: Tensor) -> Tensor:
         noise_mask = self.get_noise_mask(old_noise)


### PR DESCRIPTION
The current noise layer nodes don't preserve unit variance on the existing latent, so unless you manually calculate/guess the factor to normalize the two noise samples being combined, the model will output incorrect results.  This node should preserve that and allow you to easily combine noise samples without worrying about normalization.

Based on the unused NoiseNormalize enum class existing I suspect this was intended to be a feature all along that might have been forgotten, so let me know if there is a different way it was intended to be implemented.  And reviewing the other noise layer nodes, I don't think that the operations that the Add and AddWeighted nodes do make mathematical sense when done on two samples of latent noise.  It would probably be justifiable to deprecate existing noise layer nodes in favor of this one, even including the replace one if wanted (since you can do the same thing by using this node with weight 1.0). This node will always result in a latent that is just as valid as its inputs, the other nodes do not uphold this guarantee.