### PR TITLE
Added overlap-linear fuse method + cleanup

### DIFF
--- a/animatediff/context.py
+++ b/animatediff/context.py
@@ -20,12 +20,18 @@ class ContextFuseMethod:
     FLAT = "flat"
     PYRAMID = "pyramid"
     RELATIVE = "relative"
-    RANDOM = "random"
-    GAUSS_SIGMA = "gauss-sigma"
-    GAUSS_SIGMA_INV = "gauss-sigma inverse"
-    DELAYED_REVERSE_SAWTOOTH = "delayed reverse sawtooth"
-    PYRAMID_SIGMA = "pyramid-sigma"
-    PYRAMID_SIGMA_INV = "pyramid-sigma inverse"
+    RANDOM = "🔬random"
+    RANDOM_DEPR = "random"
+    GAUSS_SIGMA = "🔬gauss-sigma"
+    GAUSS_SIGMA_DEPR = "gauss-sigma"
+    GAUSS_SIGMA_INV = "🔬gauss-sigma inverse"
+    GAUSS_SIGMA_INV_DEPR = "gauss-sigma inverse"
+    DELAYED_REVERSE_SAWTOOTH = "🔬delayed reverse sawtooth"
+    DELAYED_REVERSE_SAWTOOTH_DEPR = "delayed reverse sawtooth"
+    PYRAMID_SIGMA = "🔬pyramid-sigma"
+    PYRAMID_SIGMA_DEPR = "pyramid-sigma"
+    PYRAMID_SIGMA_INV = "🔬pyramid-sigma inverse"
+    PYRAMID_SIGMA_INV_DEPR = "pyramid-sigma inverse"
 
     LIST = [PYRAMID, FLAT, DELAYED_REVERSE_SAWTOOTH, PYRAMID_SIGMA, PYRAMID_SIGMA_INV, GAUSS_SIGMA, GAUSS_SIGMA_INV, RANDOM]
     LIST_STATIC = [PYRAMID, RELATIVE, FLAT, DELAYED_REVERSE_SAWTOOTH, PYRAMID_SIGMA, PYRAMID_SIGMA_INV, GAUSS_SIGMA, GAUSS_SIGMA_INV, RANDOM]
@@ -455,11 +461,17 @@ FUSE_MAPPING = {
     ContextFuseMethod.PYRAMID: create_weights_pyramid,
     ContextFuseMethod.RELATIVE: create_weights_pyramid,
     ContextFuseMethod.GAUSS_SIGMA: create_weights_gauss_sigma,
+    ContextFuseMethod.GAUSS_SIGMA_DEPR: create_weights_gauss_sigma,
     ContextFuseMethod.GAUSS_SIGMA_INV: create_weights_gauss_sigma_inv,
+    ContextFuseMethod.GAUSS_SIGMA_INV_DEPR: create_weights_gauss_sigma_inv,
     ContextFuseMethod.RANDOM: create_weights_random,
+    ContextFuseMethod.RANDOM_DEPR: create_weights_random,
     ContextFuseMethod.DELAYED_REVERSE_SAWTOOTH: create_weights_delayed_reverse_sawtooth,
+    ContextFuseMethod.DELAYED_REVERSE_SAWTOOTH_DEPR: create_weights_delayed_reverse_sawtooth,
     ContextFuseMethod.PYRAMID_SIGMA: create_weights_pyramid_sigma,
+    ContextFuseMethod.PYRAMID_SIGMA_DEPR: create_weights_pyramid_sigma,
     ContextFuseMethod.PYRAMID_SIGMA_INV: create_weights_pyramid_sigma_inv,
+    ContextFuseMethod.PYRAMID_SIGMA_INV_DEPR: create_weights_pyramid_sigma_inv,
 }
 
 

--- a/animatediff/motion_module_ad.py
+++ b/animatediff/motion_module_ad.py
@@ -1387,7 +1387,7 @@ class TemporalTransformerBlock(nn.Module):
                     count += 1
                 sub_hidden_states = rearrange(sub_hidden_states, "(b f) d c -> b f d c", f=len(sub_idxs))
 
-                weights = get_context_weights(len(sub_idxs), view_options.fuse_method) * batched_conds
+                weights = get_context_weights(len(sub_idxs), video_length, sub_idxs, view_options, sigma=transformer_options["sigmas"]) * batched_conds
                 weights_tensor = torch.Tensor(weights).to(device=hidden_states.device).unsqueeze(0).unsqueeze(-1).unsqueeze(-1)
                 value_final[:, sub_idxs] += sub_hidden_states * weights_tensor
                 count_final[:, sub_idxs] += weights_tensor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-animatediff-evolved"
 description = "Improved AnimateDiff integration for ComfyUI."
-version = "1.5.1"
+version = "1.5.2"
 license = { file = "LICENSE" }
 dependencies = []
 


### PR DESCRIPTION
- Added ```overlap-linear``` fuse method; only applies non-1 weights to overlapped sections of contexts
- To do the above, added more params to be passed into weights code, allowing for more advanced fuse methods
- Fixed sigma-related fuse methods not working with View Options
- Labeled experimental fuse methods appropriately to make fuse_methods dropdowns less intimidating