### PR TITLE
Js updates

### DIFF
--- a/web/js/deprecate_nodes.js
+++ b/web/js/deprecate_nodes.js
@@ -1,54 +1,7 @@
 import { app } from '../../../scripts/app.js'
 
-app.ui.settings.addSetting({
-    id: "ADE.ShowExperimental",
-    name: "🎭🅐🅓 Show experimental nodes",
-    type: "boolean",
-    defaultValue: false,
-});
-app.ui.settings.addSetting({
-    id: "ADE.ShowDeprecated",
-    name: "🎭🅐🅓 Show deprecated nodes",
-    type: "boolean",
-    defaultValue: false,
-});
-
 const deprecate_nodes = {
     name: 'AnimateDiff.deprecate_nodes',
-    async beforeRegisterNodeDef(nodeType, nodeData, app) {
-        let showDeprecated = app.ui.settings.getSettingValue("ADE.ShowDeprecated", false)
-        let showExperimental = app.ui.settings.getSettingValue("ADE.ShowExperimental", false)
-        let warnWidget = false
-        if (nodeData?.input?.optional) {
-            for (let w in nodeData.input.optional) {
-                if (nodeData.input.optional[w][0] == "ADEWARN") {
-                    warnWidget = nodeData.input.optional[w]
-                    break
-                }
-            }
-        }
-        if (warnWidget) {
-            if (!((warnWidget[1].warn_type || "deprecated") == "deprecated" && showDeprecated) &&
-                !(warnWidget[1].warn_type == "experimental" && showExperimental)) {
-                nodeType.filter = "hidden"
-            }
-        }
-        if (!nodeType.filter) {
-            nodeType.filter = app.graph.filter
-        }
-
-    },
-    async init() {
-        app.graph.filter = app.graph.filter || "shown"
-    },
-    async setup() {
-        for (let k in LiteGraph.registered_node_types) {
-            let nodeType = LiteGraph.registered_node_types[k]
-            if (!nodeType.filter) {
-                nodeType.filter = app.graph.filter
-            }
-        }
-    },
     async getCustomWidgets() {
         return {
             ADEWARN(node, inputName, inputData) {

--- a/web/js/documentation.js
+++ b/web/js/documentation.js
@@ -24,22 +24,22 @@ function initHelpDOM() {
     parentDOM.appendChild(helpDOM)
     helpDOM.className = "litegraph";
     let scrollbarStyle = document.createElement('style');
+    parentDOM.className = "VHS_floatinghelp"
     scrollbarStyle.innerHTML = `
-    <style id="scroll-properties">
-            * {
+            .VHS_floatinghelp {
                 scrollbar-width: 6px;
                 scrollbar-color: #0003  #0000;
-            }
-            ::-webkit-scrollbar {
-                background: transparent;
-                width: 6px;
-            }
-            ::-webkit-scrollbar-thumb {
-                background: #0005;
-                border-radius: 20px
-            }
-            ::-webkit-scrollbar-button {
-                display: none;
+                &::-webkit-scrollbar {
+                    background: transparent;
+                    width: 6px;
+                }
+                &::-webkit-scrollbar-thumb {
+                    background: #0005;
+                    border-radius: 20px
+                }
+                &::-webkit-scrollbar-button {
+                    display: none;
+                }
             }
             .VHS_loopedvideo::-webkit-media-controls-mute-button {
                 display:none;
@@ -47,7 +47,6 @@ function initHelpDOM() {
             .VHS_loopedvideo::-webkit-media-controls-fullscreen-button {
                 display:none;
             }
-        </style>
     `
     parentDOM.appendChild(scrollbarStyle)
     chainCallback(app.canvas, "onDrawForeground", function (ctx, visible_rect){


### PR DESCRIPTION
Remove old deprecation code and settings. ADEWARN now only exists to display a text warning on nodes. From my reading, all nodes have already been updated on the python side with the new DEPRECATED or EXPERIMENTAL option.

Restricts documentation styling so that scrollbar style changes don't leak into core ui elements.