### PR TITLE
Bump version to 1.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-animatediff-evolved"
 description = "Improved AnimateDiff integration for ComfyUI."
-version = "1.5.7"
+version = "1.6.0"
 license = { file = "LICENSE" }
 dependencies = []
 


### PR DESCRIPTION
## Summary

- bump the Comfy Registry package version to 1.6.0
- release the V3 node conversions now on main

## Validation

- parsed pyproject.toml with Python tomllib
- git diff --check